### PR TITLE
More overloads

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -23,8 +23,7 @@ type
 # Open connection to database, make sure to close connection when finished
 let db = newConn(":memory:")
 # Create the tables
-db.create(Customer)
-db.create(Order)
+db.create(Customer, Order)
 ```
 
 Now you can start inserting data

--- a/src/ponairi.nim
+++ b/src/ponairi.nim
@@ -500,8 +500,8 @@ macro load*[C: object](db; child: C, field: untyped): object =
         owner {.references: User.id.}: int64
         name: string
 
-    db.create(User)
-    db.create(Item)
+    db.create(User, Item)
+
     let
       ownerID = db.insertID(User(name: "Jake"))
       item = Item(owner: ownerID, name: "Lamp")

--- a/src/ponairi.nim
+++ b/src/ponairi.nim
@@ -434,8 +434,26 @@ proc upsert*[T: object](db; items: openArray[T]) =
 
 proc create*[T: object](db; table: typedesc[T]) =
   ## Creates a table in the database that reflects an object
+  runnableExamples:
+    let db = newConn(":memory:")
+    # Create object
+    type Something = object
+      foo, bar: int
+    # Use `create` to make a table named 'something' with field reflecting`Something`
+    db.create Something
+  #==#
   const schema = createSchema(T)
   db.exec(schema)
+
+macro create*(db; tables: varargs[typed]) =
+  ## Creates multiple classes at once
+  ##
+  ## - See [create(db, table)]
+  result = newStmtList()
+  for table in tables:
+    if table.kind != nnkSym:
+      "Only type names should be passed".error(tables)
+    result &= nnkCall.newTree(ident"create", db, table)
 
 proc drop*[T: object](db; table: typedesc[T]) =
   ## Drops a table from the database

--- a/src/ponairi.nim
+++ b/src/ponairi.nim
@@ -1,6 +1,5 @@
 import std/macros
 import std/strformat
-import std/parseutils
 import std/macrocache
 import std/strutils
 import std/options
@@ -528,10 +527,18 @@ iterator find*[T: object | tuple](db; table: typedesc[seq[T]], query: SqlQuery, 
     row.to(res)
     yield res
 
-iterator find*[T: object | tuple](db; table: typedesc[seq[T]]): T =
+iterator find*[T: object](db; table: typedesc[seq[T]]): T =
   ## Returns all rows that belong to **table**
   for row in db.find(table, sql("SELECT * FROM " & $T)):
     yield row
+
+proc find*[T: object | tuple](db; table: typedesc[seq[T]], query: SqlQuery, args): seq[T] =
+  for row in db.find(table, query, args):
+    result &= row
+
+proc find*[T: object](db; table: typedesc[seq[T]]): seq[T] =
+  for row in db.find(table):
+    result &= row
 
 macro createUniqueWhere[T: object](table: typedesc[T]): (bool, string) =
   ## Returns a WHERE clause that can be used to uniquely identify an object in

--- a/tests/testAll.nim
+++ b/tests/testAll.nim
@@ -23,9 +23,7 @@ type
 let db = newConn(":memory:")
 
 test "Table creation":
-  db.create(Person)
-  db.create(Dog)
-  db.create(Something)
+  db.create(Person, Dog, Something)
 
 const
   jake = Person(name: "Jake", age: 42, alive: true)

--- a/tests/testAll.nim
+++ b/tests/testAll.nim
@@ -1,7 +1,6 @@
 import std/[
   unittest,
-  options,
-  sequtils
+  options
 ]
 import ponairi {.all.}
 
@@ -19,6 +18,7 @@ type
   Something* = object
     name*, age*: string
     another {.references: Person.name, cascade.}: string
+
 
 let db = newConn(":memory:")
 
@@ -53,18 +53,18 @@ test "Try find":
   check db.find(Option[Person], sql"SELECT * FROM Person").isSome()
 
 test "Find all":
-  check db.find(seq[Person]).toSeq().len == 2
+  check db.find(seq[Person]).len == 2
 
 test "Insert with relation":
   db.insert(jakesDogs)
 
 test "Find with relation":
-  let dogs = db.find(seq[Dog], sql"SELECT * FROM Dog WHERE owner = 'Jake'").toSeq()
+  let dogs = db.find(seq[Dog], sql"SELECT * FROM Dog WHERE owner = 'Jake'")
   check dogs == jakesDogs
 
 when false:
   test "Auto find with relation":
-    check jakesDogs == db.findAllFor(Dog, Person).toSeq()
+    check jakesDogs == db.findAllFor(Dog, Person)
 
 test "Load parent in relation":
   let dog = jakesDogs[0]
@@ -74,13 +74,13 @@ test "Upsert":
   let oldVal = jakesDogs[0]
   var dog = jakesDogs[0]
   dog.name = "Soemthing else"
-  check dog notin db.find(seq[Dog]).toSeq()
+  check dog notin db.find(seq[Dog])
   db.upsert(dog)
-  check dog in db.find(seq[Dog]).toSeq()
+  check dog in db.find(seq[Dog])
   db.upsert(oldVal)
 
 test "Finding to tuples":
-  let pairs = db.find(seq[tuple[owner: string, dog: string]], sql"SELECT Person.name, Dog.name FROM Dog JOIN Person ON Person.name = Dog.owner ").toSeq
+  let pairs = db.find(seq[tuple[owner: string, dog: string]], sql"SELECT Person.name, Dog.name FROM Dog JOIN Person ON Person.name = Dog.owner ")
   for row in pairs:
     check row.owner == "Jake"
     check row.dog != ""
@@ -88,7 +88,7 @@ test "Finding to tuples":
 test "Delete item":
   let dog = jakesDogs[0]
   db.delete(dog)
-  check dog notin db.find(seq[Dog]).toSeq()
+  check dog notin db.find(seq[Dog])
   db.insert(dog)
 
 test "Exists":
@@ -126,7 +126,7 @@ test "Store times":
   let exercise = Exercise(time: currTime, date: now)
   db.insert(exercise)
 
-  check db.find(seq[Exercise]).toSeq()[0] == exercise
+  check db.find(seq[Exercise])[0] == exercise
 
 test "Exists without primary key":
   type


### PR DESCRIPTION
- `find(seq[T])` now has both iterator and seq returning version
- `create` can now take a list of tables to create