### PR TITLE
Support enums

### DIFF
--- a/src/ponairi.nim
+++ b/src/ponairi.nim
@@ -206,7 +206,7 @@ func isPrimary(prop: Property): bool =
   result = "primary" in prop.pragmas
 
 func sqlType*(T: typedesc[string]): string {.inline.} = "TEXT"
-func sqlType*(T: typedesc[SomeInteger]): string {.inline.} = "INTEGER"
+func sqlType*(T: typedesc[SomeOrdinal]): string {.inline.} = "INTEGER"
 func sqlType*(T: typedesc[bool]): string {.inline.} = "BOOL"
 func sqlType*[V](T: typedesc[Option[V]]): string {.inline.} = sqlType(V)
 # We store Time as UNIX time and DateTime in sqlites format (Both in utc)
@@ -469,8 +469,11 @@ proc dbValue*(d: DateTime): DbValue =
 proc dbValue*(t: Time): DbValue =
   result = DbValue(kind: dvkInt, i: t.toUnix())
 
+func dbValue*(e: enum): DbValue =
+  result = DbValue(kind: dvkInt, i: e.ord)
+
 func to*(src: DbValue, dest: var string) {.inline.} = dest = src.s
-func to*[T: SomeInteger](src: DbValue, dest: var T) {.inline.} = dest = T(src.i)
+func to*[T: SomeOrdinal](src: DbValue, dest: var T) {.inline.} = dest = T(src.i)
 func to*[T](src: DbValue, dest: var Option[T]) =
   if src.kind != dvkNull:
     var val: T

--- a/tests/testAll.nim
+++ b/tests/testAll.nim
@@ -5,10 +5,15 @@ import std/[
 import ponairi {.all.}
 
 type
+  Status = enum
+    Alive
+    Dead
+    Undead # Our schema supports zombie apocalypse
+
   Person = object
     name {.primary.}: string
     age: int
-    alive*: bool
+    status*: Status
     extraInfo: Option[string]
 
   Dog* = object
@@ -26,8 +31,8 @@ test "Table creation":
   db.create(Person, Dog, Something)
 
 const
-  jake = Person(name: "Jake", age: 42, alive: true)
-  john = Person(name: "John", age: 45, alive: false, extraInfo: some "Test")
+  jake = Person(name: "Jake", age: 42, status: Alive)
+  john = Person(name: "John", age: 45, status: Dead, extraInfo: some "Test")
 
 const jakesDogs = [
   Dog(owner: "Jake", name: "Dog"),


### PR DESCRIPTION
They are converted to/from integers and stored like that in the database

No need to have a seperate table for them to get string values since we can just get that in the Nim code