### PR TITLE
Allow ignoring fields in `upsert`

### DIFF
--- a/src/ponairi.nim
+++ b/src/ponairi.nim
@@ -360,18 +360,14 @@ proc insert*[T: SomeTable](db; items: openArray[T]) =
     for item in items:
       db.insert item
 
-proc upsertImpl*[T: SomeTable](db; item: T, exclude: static[openArray[string]] = []) =
+proc upsertImpl[T: SomeTable](db; item: T, exclude: static[openArray[string]] = []) =
   const query = createUpsert(T, exclude)
   var params: seq[DbValue]
   for name, field in item.fieldPairs:
     params &= dbValue(field)
   db.exec(query, params)
 
-proc upsertImpl*[T: SomeTable](db; items: openArray[T], exclude: static[openArray[string]] = []) =
-  ## Upsets a list of items into the database
-  ##
-  ## - See [upsert(db, item)]
-  ## - See [insert(db, items)]
+proc upsertImpl[T: SomeTable](db; items: openArray[T], exclude: static[openArray[string]] = []) =
   db.transaction:
     for item in items:
       db.upsertImpl(item, exclude)

--- a/src/ponairi/macroUtils.nim
+++ b/src/ponairi/macroUtils.nim
@@ -1,0 +1,120 @@
+import std/[
+  macrocache,
+  macros
+]
+
+type
+  Pragma* = object
+    ## Represents a pragma attached to a field/table
+    name*: string
+    parameters*: seq[NimNode]
+
+  Property* = object
+    ## Represents a property of an object
+    name*: string
+    typ*: NimNode
+    # I don't think a person will have too many pragmas so a seq should be fine for now
+    pragmas*: seq[Pragma]
+
+when not declared(macrocache.contains):
+  # Naive version for when on old versions of Nim
+  proc contains*(t: CacheTable, key: string): bool =
+    for k, val in pairs(t):
+      if k == key: return true
+
+func initPragma*(pragmaVal: NimNode): Pragma =
+  ## Creates a pragma object from nnkPragmaExpr node
+  case pragmaVal.kind
+  of nnkCall, nnkExprColonExpr:
+    result.name = pragmaVal[0].strVal
+    for parameter in pragmaVal[1..^1]:
+      result.parameters &= parameter
+  else:
+    result.name = pragmaVal.strVal
+
+func getTable*(pragma: Pragma): string =
+  ## Returns name of table for references pragma
+  pragma.parameters[0][0].strVal
+
+func getColumn*(pragma: Pragma): string =
+  ## Returns name of column for references pragma
+  pragma.parameters[0][1].strVal
+
+# I know these operations are slow, but I want to make it work first
+func contains*(items: seq[Pragma], name: string): bool =
+  for item in items:
+    if item.name.eqIdent(name): return true
+
+func `[]`*(items: seq[Pragma], name: string): Pragma =
+  for item in items:
+    if item.name.eqIdent(name): return item
+
+proc getName*(n: NimNode): string =
+  case n.kind
+  of nnkIdent, nnkSym:
+    result = n.strVal
+  of nnkPostFix:
+    result = n[1].getName()
+  of nnkTypeDef:
+    result = n[0].getName()
+  else:
+    echo n.treeRepr
+    assert false, "Name is invalid"
+
+proc getProperties*(impl: NimNode): seq[Property] =
+  for identDef in impl[2][2]:
+    for property in identDef[0 ..< ^2]:
+      var newProp = Property(typ: identDef[^2])
+      if property.kind == nnkPragmaExpr:
+        newProp.name = property[0].getName
+        for pragma in property[1]:
+          newProp.pragmas &= initPragma(pragma)
+      else:
+        newProp.name = property.getName
+      result &= newProp
+
+proc lookupImpl*(T: NimNode): NimNode =
+  ## Performs a series of magical lookups to get the original
+  ## type def of something
+  result = T
+  while result.kind != nnkTypeDef:
+    case result.kind
+    of nnkSym:
+      let impl = result.getImpl()
+      if impl.kind == nnkNilLit:
+        result = result.getTypeImpl()
+      else:
+        result = impl
+    of nnkBracketExpr:
+      result = result[1]
+    of nnkIdentDefs:
+      result = result[0].getTypeInst()
+    else:
+      echo result.treeRepr
+      "Beans misconfigured: Could not look up type".error(T)
+
+
+func isOptional*(prop: Property): bool =
+  ## Returns true if the property has an optional type
+  result = prop.typ.kind == nnkBracketExpr and prop.typ[0].eqIdent("Option")
+
+func isPrimary*(prop: Property): bool =
+  ## Returns true if the property is a primary key
+  result = "primary" in prop.pragmas
+
+const properties = CacheTable"ponairi.properties"
+
+proc hasProperty*(obj: NimNode, property: string | NimNode): bool =
+  let key = obj.strVal
+  if key in properties:
+    # Do simple linear scan for property
+    for prop in properties[key]:
+      if prop.eqIdent(property): # TODO: Maybe normalise first to make comparison quicker?
+        return true
+  else:
+    var props = newStmtList()
+    for properties in obj.lookupImpl().getProperties():
+      props &= ident properties.name
+    properties[key] = props
+    # TODO: Run check while adding? Don't think that would cause too much slowdown tho
+    result = obj.hasProperty(property)

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,1 @@
+testAll

--- a/tests/testAll.nim
+++ b/tests/testAll.nim
@@ -77,6 +77,13 @@ test "Upsert":
   check dog in db.find(seq[Dog])
   db.upsert(oldVal)
 
+test "Upsert can ignore fields":
+  let oldVal = jake
+  var person = jake
+  person.age = int.high
+  db.upsert(person, ["age"])
+  check db.find(Option[Person], sql"SELECT * FROM Person WHERE age = ?", person.age).isNone()
+
 test "Finding to tuples":
   let pairs = db.find(seq[tuple[owner: string, dog: string]], sql"SELECT Person.name, Dog.name FROM Dog JOIN Person ON Person.name = Dog.owner ")
   for row in pairs:

--- a/tests/testAll.nim
+++ b/tests/testAll.nim
@@ -81,8 +81,14 @@ test "Upsert can ignore fields":
   let oldVal = jake
   var person = jake
   person.age = int.high
-  db.upsert(person, ["age"])
+  db.upsert(person, age)
   check db.find(Option[Person], sql"SELECT * FROM Person WHERE age = ?", person.age).isNone()
+
+test "Upsert a sequence":
+  db.upsert(jakesDogs)
+
+test "Upsert check fields exist":
+  check not compiles(db.upsert(jake, test))
 
 test "Finding to tuples":
   let pairs = db.find(seq[tuple[owner: string, dog: string]], sql"SELECT Person.name, Dog.name FROM Dog JOIN Person ON Person.name = Dog.owner ")

--- a/tests/testMacros.nim
+++ b/tests/testMacros.nim
@@ -13,6 +13,7 @@ type
     name: string
     age: int
     a, b: string
+
 {.experimental: "dynamicBindSym".}
 proc getSym(x: typedesc): NimNode = bindSym($x)
 

--- a/tests/testMacros.nim
+++ b/tests/testMacros.nim
@@ -1,0 +1,28 @@
+## Tests for macro utils
+
+import std/[
+  unittest,
+  macros,
+  strutils
+]
+import ponairi/macroUtils
+
+
+type
+  Person = object
+    name: string
+    age: int
+    a, b: string
+{.experimental: "dynamicBindSym".}
+proc getSym(x: typedesc): NimNode = bindSym($x)
+
+test "Check object has a property":
+  const passed = static:
+    var res = true
+    for field, value in Person().fieldPairs:
+      let fieldName =  astToStr(field).strip(chars = {'"'})
+      if not Person.getSym().hasProperty(fieldName):
+        checkpoint("Doesn't have: " & fieldName)
+        res = false
+    res
+  check passed


### PR DESCRIPTION
You can now ignore certain fields when upserting.

Useful if constructing the object without the database and don't want to reset some values

```nim
type
  Foo = object
    a {.primary.}: int
    b: bool
    c: string
let db = newConn(":memory:")
db.insert Foo(a: 9, b: true, c: "Hello")
# We can now upsert, but we don't want to update `c`
db.upsert(Foo(a: 9, b: false), c)
```

Implemented with a macro so that the properties can have proper compile time errors