### PR TITLE
Query builder

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,4 +40,4 @@ jobs:
       run: nimble test
 
     - name: Test doc examples
-      run: nimble doc --warningAsError:BrokenLink:on --project src/ponairi.nim
+      run: nimble checkDocs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
         path: ~/.nimble
         key: nimble-${{ hashFiles('*.nimble') }}
 
-    - if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
+    - if: ${{ steps.cache-choosenim.outputs.cache-hit != 'true' }}
       name: Install nim dependencies
       continue-on-error: true
       run: nimble update && nimble install

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+outputGotten.txt

--- a/ponairi.nimble
+++ b/ponairi.nimble
@@ -11,7 +11,7 @@ srcDir        = "src"
 # Dependencies
 
 requires "nim >= 1.6.0"
-requires "https://github.com/PhilippMDoerner/ndb.nim#59043f7"
+requires "lowdb >= 0.1.1"
 
 task checkDocs, "Runs documentation generator to make sure nothing is wrong":
   exec "nimble doc --errorMax:1 --warningAsError:BrokenLink:on --project --outdir:docs src/ponairi.nim"

--- a/ponairi.nimble
+++ b/ponairi.nimble
@@ -1,3 +1,4 @@
+import os
 # Package
 
 version       = "0.1.0"
@@ -14,3 +15,10 @@ requires "https://github.com/PhilippMDoerner/ndb.nim#59043f7"
 
 task checkDocs, "Runs documentation generator to make sure nothing is wrong":
   exec "nimble doc --errorMax:1 --warningAsError:BrokenLink:on --project --outdir:docs src/ponairi.nim"
+
+task test, "Runs all tests":
+  # Run the unittest files
+  for file in ["All", "Macros"]:
+    selfExec "r tests/test" & file
+  # Run testament
+  exec "testament all"

--- a/ponairi.nimble
+++ b/ponairi.nimble
@@ -21,4 +21,4 @@ task test, "Runs all tests":
   for file in ["All", "Macros"]:
     selfExec "r tests/test" & file
   # Run testament
-  exec "testament all"
+  exec "nim r tests/errorChecker tests/errors/t*.nim"

--- a/ponairi.nimble
+++ b/ponairi.nimble
@@ -11,3 +11,6 @@ srcDir        = "src"
 
 requires "nim >= 1.6.0"
 requires "https://github.com/PhilippMDoerner/ndb.nim#59043f7"
+
+task checkDocs, "Runs documentation generator to make sure nothing is wrong":
+  exec "nimble doc --warningAsError:BrokenLink:on --project --outdir:docs src/ponairi.nim"

--- a/ponairi.nimble
+++ b/ponairi.nimble
@@ -13,4 +13,4 @@ requires "nim >= 1.6.0"
 requires "https://github.com/PhilippMDoerner/ndb.nim#59043f7"
 
 task checkDocs, "Runs documentation generator to make sure nothing is wrong":
-  exec "nimble doc --warningAsError:BrokenLink:on --project --outdir:docs src/ponairi.nim"
+  exec "nimble doc --errorMax:1 --warningAsError:BrokenLink:on --project --outdir:docs src/ponairi.nim"

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Pónairí 🫘
 
-Simple ORM to handle basic CRUD tasks. Future plans are to expand the query generation to make needing to write SQL less common
+Simple ORM to handle basic CRUD tasks
 
 [Docs here](https://tempdocs.netlify.app/ponairi/stable/ponairi.html)
 
@@ -11,14 +11,14 @@ To start you want to create your objects that will define your schema
 ```nim
 type
   Customer = object
-    id {.primary, autoIncrement.}: int64
+    id {.primary, autoIncrement.}: int
     email: string
     firstName, lastName: string
 
   Order = object
-    id {.primary, autoIncrement.}: int64
+    id {.primary, autoIncrement.}: int
     name: string
-    customer {.references: Customer.id.}: int64
+    customer {.references: Customer.id.}: int
 
 # Open connection to database, make sure to close connection when finished
 let db = newConn(":memory:")
@@ -67,6 +67,17 @@ Currently there is some support for automatically loading objects through refere
 # We want to load the object that is referenced by tableOrder in the customer field
 let customer = db.load(tableOrder, customer)
 assert customer is Customer
+```
+
+There is also a type safe query building API that allows you to write queries that are checked at compile time.
+This doesn't replace SQL since its a smaller subset (Only focused on writing where statements)
+
+```nim
+# Using the examples before
+# The integer comparision (customer == int param) and the parameter passed (john.id)
+# are both checked at compile time that they are the correct types
+echo db.find(Order.where(customer == ?int), john.id)
+assert db.find(Option[order].where(customer == 99999)).isNone
 ```
 
 ### Update

--- a/src/ponairi.nim
+++ b/src/ponairi.nim
@@ -70,7 +70,6 @@ db.insert(Person(name: "Jake", age: 42))
 
 [find] is used for all operations relating to getting objects from a database.
 It uses a type based API where the first parameter (after the db connection) determines the return type.
-Currently most tasks require you to write SQL yourself but this will hopefully change in the future
 
 ```nim
 # Gets the Object we created before
@@ -88,6 +87,9 @@ for person in db.find(seq[Person], sql"SELECT * FROM Person WHERE age > 1"):
 for person in db.find(seq[Person]):
   echo person
 ```
+
+There is also a [query building API](ponairi/queryBuilder.html) that enables type safe query construction for
+simple where statements
 
 #### Update
 

--- a/src/ponairi.nim
+++ b/src/ponairi.nim
@@ -222,6 +222,7 @@ template fieldPairs(x: ref object): untyped = fieldPairs(x[])
 macro createSchema(T: typedesc[SomeTable]): SqlQuery =
   ## Returns a string that can be used to create a table in a database
   let impl = T.lookupImpl()
+  registerTable(impl.getNameSym)
   result = newLit(fmt"CREATE TABLE IF NOT EXISTS {impl.getName()} (")
   let properties = impl.getProperties()
   # Keep list of primary keys so that we can generate them last.

--- a/src/ponairi.nim
+++ b/src/ponairi.nim
@@ -169,6 +169,7 @@ func sqlType*(T: typedesc[string]): string {.inline.} = "TEXT"
 func sqlType*(T: typedesc[SomeOrdinal]): string {.inline.} = "INTEGER"
 func sqlType*(T: typedesc[bool]): string {.inline.} = "BOOL"
 func sqlType*[V](T: typedesc[Option[V]]): string {.inline.} = sqlType(V)
+func sqlType*(T: typedesc[SomeFloat]): string {.inline.} = "REAL"
 # We store Time as UNIX time and DateTime in sqlites format (Both in utc)
 func sqlType*(T: typedesc[Time]): string {.inline.} = "INTEGER"
 func sqlType*(T: typedesc[DateTime]): string {.inline.} = "TEXT"
@@ -426,6 +427,7 @@ func dbValue*(e: enum): DbValue =
 
 func to*(src: DbValue, dest: var string) {.inline.} = dest = src.s
 func to*[T: SomeOrdinal](src: DbValue, dest: var T) {.inline.} = dest = T(src.i)
+func to*[T: SomeFloat](src: DbValue, dest: var T) {.inline.} = dest = T(src.f)
 func to*[T](src: DbValue, dest: var Option[T]) =
   if src.kind != dvkNull:
     when T is SomeTable:

--- a/src/ponairi.nim
+++ b/src/ponairi.nim
@@ -4,7 +4,7 @@ import std/macrocache
 import std/strutils
 import std/options
 import std/times
-import ndb/sqlite except `?`
+import lowdb/sqlite except `?`
 
 import ponairi/[
   pragmas,

--- a/src/ponairi.nim
+++ b/src/ponairi.nim
@@ -160,7 +160,7 @@ runnableExamples:
 #==#
 
 type
-  SomeTable* = (ref[object] | object) and not TableQuery[object]
+  SomeTable* = (ref[object] | object) and not TableQuery[auto]
     ## Supported types for reprsenting table schema
 
 const dateFormat = "yyyy-MM-dd HH:mm:ss'.'fff"

--- a/src/ponairi.nim
+++ b/src/ponairi.nim
@@ -576,4 +576,4 @@ export hasCustomPragma # Wouldn't bind
 export replace
 export queryBuilder
 export pragmas
-export sqlite except `?`
+export sqlite

--- a/src/ponairi.nim
+++ b/src/ponairi.nim
@@ -436,7 +436,7 @@ func dbValue*(e: enum): DbValue =
 func to*(src: DbValue, dest: var string) {.inline.} = dest = src.s
 func to*[T: SomeOrdinal](src: DbValue, dest: var T) {.inline.} = dest = T(src.i)
 func to*[T: SomeFloat](src: DbValue, dest: var T) {.inline.} = dest = T(src.f)
-func to*[T](src: DbValue, dest: var Option[T]) =
+proc to*[T](src: DbValue, dest: var Option[T]) =
   if src.kind != dvkNull:
     when T is SomeTable:
       var val = T()

--- a/src/ponairi.nim
+++ b/src/ponairi.nim
@@ -160,7 +160,7 @@ runnableExamples:
 #==#
 
 type
-  SomeTable* = ref[object] | object
+  SomeTable* = (ref[object] | object) and not TableQuery[object]
     ## Supported types for reprsenting table schema
 
 const dateFormat = "yyyy-MM-dd HH:mm:ss'.'fff"
@@ -264,7 +264,7 @@ macro createSchema(T: typedesc[SomeTable]): SqlQuery =
       result.join ", "
   if primaryKeys.len > 0:
     result.join ", PRIMARY KEY (" & primaryKeys.join(", ") & ")"
-  result.join ")"
+  result.join ") STRICT"
   result = sqlLit(result)
 
 macro createInsert[T: SomeTable](table: typedesc[T]): SqlQuery =

--- a/src/ponairi.nim
+++ b/src/ponairi.nim
@@ -6,7 +6,10 @@ import std/options
 import std/times
 import ndb/sqlite
 
-import ponairi/pragmas
+import ponairi/[
+  pragmas,
+  queryBuilder
+]
 
 ##[
 Pónairí can be used when all you need is a simple ORM for CRUD tasks.
@@ -196,6 +199,7 @@ func contains(items: seq[Pragma], name: string): bool =
 func `[]`(items: seq[Pragma], name: string): Pragma =
   for item in items:
     if item.name.eqIdent(name): return item
+
 
 func isOptional(prop: Property): bool =
   ## Returns true if the property has an optional type
@@ -609,5 +613,6 @@ proc exists*[T: object](db; item: T): bool =
 
 export hasCustomPragma # Wouldn't bind
 export replace
+export queryBuilder
 export pragmas
 export sqlite

--- a/src/ponairi.nim
+++ b/src/ponairi.nim
@@ -4,7 +4,7 @@ import std/macrocache
 import std/strutils
 import std/options
 import std/times
-import ndb/sqlite
+import ndb/sqlite except `?`
 
 import ponairi/[
   pragmas,
@@ -572,4 +572,4 @@ export hasCustomPragma # Wouldn't bind
 export replace
 export queryBuilder
 export pragmas
-export sqlite
+export sqlite except `?`

--- a/src/ponairi.nim
+++ b/src/ponairi.nim
@@ -267,7 +267,7 @@ macro createSchema(T: typedesc[SomeTable]): SqlQuery =
       result.join ", "
   if primaryKeys.len > 0:
     result.join ", PRIMARY KEY (" & primaryKeys.join(", ") & ")"
-  result.join ") STRICT"
+  result.join ")"
   result = sqlLit(result)
 
 macro createInsert[T: SomeTable](table: typedesc[T]): SqlQuery =

--- a/src/ponairi/macroUtils.nim
+++ b/src/ponairi/macroUtils.nim
@@ -112,6 +112,8 @@ const properties = CacheTable"ponairi.properties"
 
 proc registerTable*(obj: NimNode) =
   ## Adds a tables properties to the properties cache table
+  if obj.strVal in properties:
+    return
   var props = newStmtList()
   # Convert the properties to identDefs and save in the table.
   # This is still better than accessing the object raw since it means properties like

--- a/src/ponairi/macroUtils.nim
+++ b/src/ponairi/macroUtils.nim
@@ -99,10 +99,6 @@ proc lookupImpl*(T: NimNode): NimNode =
       echo result.treeRepr
       "Beans misconfigured: Could not look up type".error(T)
 
-macro lookupImpl*(typ: typedesc): NimNode =
-  result = newCall("lookupImpl", typ)
-
-
 func isOptional*(prop: Property | NimNode): bool =
   ## Returns true if the property has an optional type
   when prop is Property:
@@ -134,6 +130,7 @@ proc getType*(obj: NimNode, property: string | NimNode): Option[NimNode] =
   ## Returns the type for a property if it exists
   let key = obj.strVal
   if key in properties:
+    echo properties[key].treeRepr
     for prop in properties[key]:
       if prop[0].eqIdent(property):
         return some prop[1]
@@ -166,3 +163,16 @@ func newBlockExpr*(body: varargs[NimNode]): NimNode =
   for item in body:
     bodyItems &= item
   result = newBlockStmt(bodyItems)
+
+proc error*(msg: string, line: LineInfo) =
+  ## Sets an error to be on a specific line
+  let tmp = newEmptyNode()
+  when defined(macros.setLineInfo):
+    tmp.setLineInfo(line)
+  msg.error(tmp)
+
+func newLit*[T](x: openArray[T]): NimNode =
+  var items = nnkBracket.newTree()
+  for item in x:
+    items &= newLit item
+  result = items.prefix("@")

--- a/src/ponairi/macroUtils.nim
+++ b/src/ponairi/macroUtils.nim
@@ -17,9 +17,9 @@ type
     # I don't think a person will have too many pragmas so a seq should be fine for now
     pragmas*: seq[Pragma]
 
-const identNodes = {nnkIdent, nnkSym}
+const identNodes* = {nnkIdent, nnkSym}
 
-func isIdent(x: NimNode): bool =
+func isIdent*(x: NimNode): bool =
   ## Returns if the node is an ident type (See identNodes)
   x.kind in identNodes
 
@@ -196,4 +196,21 @@ func newLit*[T](x: openArray[T]): NimNode =
   var items = nnkBracket.newTree()
   for item in x:
     items &= newLit item
-  result = items.prefix("@")
+  result = items.prefix("@") # TODO: Maybe just return an array?
+
+func makeError*(msg: string, line: LineInfo): NimNode =
+  ## Makes an error pragma with line info correctly set.
+  result = nnkPragma.newTree(
+    nnkExprColonExpr.newTree(
+      ident"error",
+      newLit msg
+    )
+  )
+  result.setLineInfo(line)
+
+const testSeq = CacheSeq"test"
+
+when not compiles(testSeq[^1]):
+  # Stolen from my Nim PR =P
+  proc `[]`*(s: CacheSeq; i: BackwardsIndex): NimNode =
+    s[s.len - int(i)]

--- a/src/ponairi/macroUtils.nim
+++ b/src/ponairi/macroUtils.nim
@@ -130,7 +130,6 @@ proc getType*(obj: NimNode, property: string | NimNode): Option[NimNode] =
   ## Returns the type for a property if it exists
   let key = obj.strVal
   if key in properties:
-    echo properties[key].treeRepr
     for prop in properties[key]:
       if prop[0].eqIdent(property):
         return some prop[1]
@@ -167,7 +166,7 @@ func newBlockExpr*(body: varargs[NimNode]): NimNode =
 proc error*(msg: string, line: LineInfo) =
   ## Sets an error to be on a specific line
   let tmp = newEmptyNode()
-  when defined(macros.setLineInfo):
+  when declared(macros.setLineInfo):
     tmp.setLineInfo(line)
   msg.error(tmp)
 

--- a/src/ponairi/macroUtils.nim
+++ b/src/ponairi/macroUtils.nim
@@ -130,6 +130,7 @@ proc registerTable*(obj: NimNode) =
       obj.lookupImpl()
     else:
       obj
+
   # Convert the properties to identDefs and save in the table.
   # This is still better than accessing the object raw since it means properties like
   # a, b, c: int

--- a/src/ponairi/macroUtils.nim
+++ b/src/ponairi/macroUtils.nim
@@ -120,6 +120,8 @@ func isPrimary*(prop: Property): bool =
   result = "primary" in prop.pragmas
 
 const properties = CacheTable"ponairi.properties"
+  ## List of properties for an object.
+  ## Is stored as a list of IdentDefs
 
 proc registerTable*(obj: NimNode) =
   ## Adds a tables properties to the properties cache table
@@ -140,6 +142,10 @@ proc registerTable*(obj: NimNode) =
   properties[if obj.isIdent: obj.strVal else: obj.getName()] = props
 
 using obj: NimNode | string
+
+proc getProperties*(key: string): seq[NimNode] =
+  for prop in properties[key]:
+    result &= prop
 
 proc getType*(obj; property: string | NimNode): Option[NimNode] =
   ## Returns the type for a property if it exists

--- a/src/ponairi/pragmas.nim
+++ b/src/ponairi/pragmas.nim
@@ -1,3 +1,5 @@
+import macroUtils
+
 ##[
 Pragmas are used to control extra info about fields such as references or how to handle deletions
 ]##
@@ -29,3 +31,8 @@ template references*(column: untyped) {.pragma.}
 
 template cascade*() {.pragma.}
   ## Turns on cascade deletion for a foreign key reference
+
+macro table*(typ: untyped): untyped =
+  ## Registers an object with ponairi without needing to use `create`.
+  registerTable(typ)
+  typ

--- a/src/ponairi/queryBuilder.nim
+++ b/src/ponairi/queryBuilder.nim
@@ -89,7 +89,8 @@ proc generateExpr(x, currentTable: NimNode, scope: seq[NimNode]): string =
     result = $x.intVal
   of nnkCall:
     # Add the current scope to any where calls
-    for param in x[1..^1]:
+    for i in 1..<x.len:
+      let param = x[i]
       template whereNode(): var NimNode = (if param[0].kind == nnkDotExpr: param[0][1] else: param[0])
 
       if whereNode.eqIdent("where"):
@@ -100,7 +101,7 @@ proc generateExpr(x, currentTable: NimNode, scope: seq[NimNode]): string =
           param[0] = bindSym "whereImpl"
         for table in scope:
           param &= table
-
+        x[i] = param
     result = fmt"{{sql{x[0].strVal}({repr(x[1])})}}"
   of nnkDotExpr:
     # Check the table they are accessing is allowed
@@ -113,7 +114,6 @@ proc generateExpr(x, currentTable: NimNode, scope: seq[NimNode]): string =
     # If found then add expression to access expression.
     # We don't need to check if property exists since that will be checked next
     result = fmt"{x[0]}.{generateExpr(x[1], x[0], scope & @[x[0]])}"
-    echo result
   of nnkBracket:
     result = "("
     for i in 0..<x.len:

--- a/src/ponairi/queryBuilder.nim
+++ b/src/ponairi/queryBuilder.nim
@@ -132,8 +132,8 @@ macro `?`*(param: untyped): QueryPart =
     typ: NimNode
     size = ""
   case param.kind
-  of nnkIdent:
-    typ = param
+  of nnkIdent, nnkSym:
+    typ = ident param.strVal
   of nnkBracket:
     if param.len != 2:
       usageMsg.error(param)

--- a/src/ponairi/queryBuilder.nim
+++ b/src/ponairi/queryBuilder.nim
@@ -74,9 +74,13 @@ proc generateExpr(x, currentTable: NimNode, scope: seq[NimNode]): string =
     else:
       fmt"{op} is not supported".error(op)
   of nnkIdent, nnkSym:
-    if not currentTable.hasProperty(x):
-      fmt"{x} doesn't exist in {currentTable}".error(x)
-    result = x.strVal
+    if x.strVal notin ["true", "false"]:
+      if not currentTable.hasProperty(x):
+        fmt"{x} doesn't exist in {currentTable}".error(x)
+      result = x.strVal
+    else:
+      # We technically could use TRUE and FALSE 
+      result = $int(x.boolVal)
   of nnkPrefix:
     if x[0].strVal == "?":
       # TODO: Check value is number

--- a/src/ponairi/queryBuilder.nim
+++ b/src/ponairi/queryBuilder.nim
@@ -267,7 +267,7 @@ func initQueryPartNode[T](x: typedesc[T], val: string = $T): NimNode =
   initQueryPartNode(ident $T, val)
 
 
-macro addParam[T](param: T, paramsIdx, idx: static[int], found: static[bool]): QueryPart[T] =
+macro addParam(param: untyped, paramsIdx, idx: static[int], found: static[bool]) =
   ## Internal proc that saves the param info into a query.
   ## This is done so we get the actual symbol and dont run into mismatches later on.
   ## It then returns what the type of the param is so teh rest of the system stays typesafe
@@ -537,8 +537,9 @@ proc exists[T](db; q: static[TableQuery[T]], params: openArray[DbValue]): bool {
 
 proc delete[T](db; q: static[TableQuery[T]], params: openArray[DbValue]) {.inline, hackyWorkaround.} =
   ## Deletes any rows that match the query
-  const table = T.tableName
-  const query = sql fmt"DELETE FROM {table} WHERE {q.whereExpr}"
+  const
+    table = T.tableName
+    query = sql fmt"DELETE FROM {table} WHERE {q.whereExpr}"
   db.exec(query, params)
 
 proc `$`*(x: TableQuery): string =

--- a/src/ponairi/queryBuilder.nim
+++ b/src/ponairi/queryBuilder.nim
@@ -418,7 +418,6 @@ macro where*(table: typedesc, query: untyped): TableQuery =
     "Query cannot be a single boolean value".error(query)
   # Add dbValue calls to convert the params
   result = newCall(bindSym"whereImpl", table, queryNodes, newLit paramsIdx)
-  echo result.toStrLit
 
 template where*[T](table: typedesc[T]): TableQuery[T] =
   ## Create a where statement that matches anything
@@ -457,7 +456,6 @@ proc checkFieldOrdering(x: typedesc, sortings: openArray[ColumnOrder]) {.compile
   ## e.g. Not calling NullsFirst on a non nullable field. not sorting something that doesn't exist
   let obj = x.tableName()
   for order in sortings:
-    echo obj.hasProperty(order.column)
     if not obj.hasProperty(order.column):
       doesntExistErr(order.column, obj).error(order.line)
 

--- a/src/ponairi/queryBuilder.nim
+++ b/src/ponairi/queryBuilder.nim
@@ -198,7 +198,7 @@ proc checkSymbols(node: NimNode, currentTable: NimNode, scope: seq[NimNode], par
       let param = node[1]
       const usageMsg = "parameters must be specified with ?[pos, typ] or ?typ"
       var
-        pos: int = params.len
+        pos: BiggestInt = params.len
         typ: NimNode
       case param.kind
       of nnkIdent, nnkSym:

--- a/src/ponairi/queryBuilder.nim
+++ b/src/ponairi/queryBuilder.nim
@@ -78,3 +78,4 @@ type
   Episode = object
 
 echo Show.where(exists(Episode.where(show == show.id and status == 0))).string
+echo Show.where(episode.id in [1, 2, 3])

--- a/src/ponairi/queryBuilder.nim
+++ b/src/ponairi/queryBuilder.nim
@@ -304,7 +304,11 @@ using args: varargs[DbValue, dbValue]
 
 func initQueryPartNode(x: NimNode, val: NimNode): NimNode =
   ## Makes a QueryPart NimNode. This doesn't make an actual QueryPart
-  let strVal = newLit(if x.eqIdent("string"): fmt"'{val.strVal}'" else: $val.toStrLit())
+  let strVal = newLit(case val.kind
+    of nnkIntLit: $val.intVal
+    of nnkFloatLit: $val.floatVal
+    of nnkStrLit: val.strVal
+    else: "")
   strVal.copyLineInfo(val)
   result = nnkCall.newTree(
     nnkBracketExpr.newTree(ident"QueryPart", x),
@@ -347,7 +351,9 @@ proc checkSymbols(node: NimNode, currentTable: NimNode, scope: seq[NimNode],
       access.copyLineInfo(node)
       return initQueryPartNode(typ.unsafeGet, access)
   of nnkStrLit:
-    return initQueryPartNode(string, node)
+    let strNode = newLit fmt"'{node.strVal}'"
+    strNode.copyLineInfo(node)
+    return initQueryPartNode(string, strNode)
   of nnkIntLit:
     return initQueryPartNode(int, node)
   of nnkFloatLit:

--- a/src/ponairi/queryBuilder.nim
+++ b/src/ponairi/queryBuilder.nim
@@ -68,7 +68,7 @@ runnableExamples:
 
   # We can write simple queries to check columns
   db.insert Item(name: "Lamp", price: 9.0)
-  assert db.find(Item.where(price > 5)).name == "Lamp"
+  assert db.find(Item.where(price > 5.0)).name == "Lamp"
 
   # We can also use parameters, only difference is we need to annotate the type.
   # The position can also be set like ?[pos, typ]
@@ -235,8 +235,8 @@ proc checkSymbols(node: NimNode, currentTable: NimNode, scope: seq[NimNode], par
       for table in scope:
         if table.eqIdent(node[0]):
           found = true
-        if not found:
-          fmt"{node[0]} is not currently accessible".error(node[0])
+      if not found:
+        fmt"{node[0]} is not currently accessible".error(node[0])
       # If found then add expression to access expression.
       # We don't need to check if property exists since that will be checked next
       let table = node[0]

--- a/src/ponairi/queryBuilder.nim
+++ b/src/ponairi/queryBuilder.nim
@@ -239,12 +239,12 @@ proc exists*[T](db; q: static[TableQuery[T]], args): bool =
   const
     table = T.tableName
     query = sql fmt"SELECT EXISTS (SELECT 1 FROM {table} WHERE {q.string} LIMIT 1)"
-  db.getValue[:int64](query).unsafeGet() == 1
+  db.getValue[:int64](query, args).unsafeGet() == 1
 
 proc delete*[T](db; q: static[TableQuery[T]], args) =
   ## Deletes any row that matches the query
   const
     table = T.tableName
     query = sql fmt"DELETE FROM {table} WHERE {q.string}"
-  db.exec(query)
+  db.exec(query, args)
 

--- a/src/ponairi/queryBuilder.nim
+++ b/src/ponairi/queryBuilder.nim
@@ -1,0 +1,65 @@
+import ndb/sqlite
+import std/[
+  macros,
+  strformat,
+  options,
+  typetraits
+]
+
+type TableQuery[T] = distinct string
+
+
+using db: DbConn
+using args: varargs[DbValue, dbValue]
+
+proc generateExpr(x: NimNode): string =
+  case x.kind
+  of nnkInfix:
+    let
+      op = x[0]
+      lhs = x[1]
+      rhs = x[2]
+    case op.strVal
+    of "==":
+      result = fmt"({generateExpr(lhs)} = {generateExpr(rhs)})"
+    of "and", "or", ">", "<", ">=", "<=", "!=":
+      result = fmt"({generateExpr(lhs)} {op.strVal} {generateExpr(rhs)})"
+    else:
+      fmt"{op} is not supported".error(op)
+  of nnkIdent, nnkSym:
+    result = x.strVal
+  of nnkPrefix:
+    if x[0].strVal == "?":
+      # TODO: Check value is number
+      result = fmt"?{x[1].intVal}"
+    else:
+      "Invalid prefix used".error(x[0])
+  of nnkStrLit:
+    result = fmt"'{x.strVal}'"
+  of nnkIntLit:
+    result = $x.intVal
+  else:
+    echo x.kind
+    "Invalid SQL query".error(x)
+
+func tableName[T](x: typedesc[T]): string =
+  result = $T
+
+func tableName[T](x: typedesc[seq[T]]): string =
+  result = $T
+
+macro where*[T](table: typedesc[T], query: untyped, variables: varargs[typed]): TableQuery[T] =
+  let whereClause =  query.generateExpr()
+  result = nnkCall.newTree(nnkBracketExpr.newTree(bindSym"TableQuery", table), newLit whereClause)
+
+proc find*[T](db; q: static[TableQuery[T]], args): T =
+  const
+    table = T.tableName
+    query = sql fmt"SELECT * FROM {table} WHERE {q.string}"
+  db.find(T, query, args)
+
+proc exists*[T](db; q: static[TableQuery[T]], args): bool =
+  const
+    table = T.tableName
+    query = sql fmt"SELECT EXISTS (SELECT 1 FROM {table} WHERE {q.string} LIMIT 1)"
+  db.getValue[:int64](query).unsafeGet() == 1

--- a/src/ponairi/queryBuilder.nim
+++ b/src/ponairi/queryBuilder.nim
@@ -1,4 +1,4 @@
-import ndb/sqlite except `?`
+import lowdb/sqlite except `?`
 import std/[
   macros,
   strformat,

--- a/src/ponairi/queryBuilder.nim
+++ b/src/ponairi/queryBuilder.nim
@@ -152,11 +152,16 @@ makeOrder(nullsLast, NullsLast):
   ## Column must be optional
 
 func buildOrderBy*(table: TableQuery): string =
-  ## Returns the ORDER BY clause
+  ## Returns the ORDER BY clause. You probably won't need to use this
+  ## But will be useful if you want to create your own functions
   runnableExamples:
-    type Person = object
-      name: string
-      age: int
+    import ponairi
+
+    type
+      Person {.table.} = object
+        name: string
+        age: int
+
     const query = seq[Person].where().orderBy(asc name, desc age)
     assert query.buildOrderBy() == "ORDER BY name ASC, age DESC"
   #==#

--- a/src/ponairi/queryBuilder.nim
+++ b/src/ponairi/queryBuilder.nim
@@ -81,12 +81,10 @@ runnableExamples:
   db.insert CartItem(item: "Lamp", cart: int(id))
 
   assert db.find(Customer.where(
-      exists(Cart.where(
-        exists(
-            CartItem.where(item == "Lamp" and cart == Cart.id)
-        )
-      ))
-  )).name == "John Doe"
+      Cart.where(
+        CartItem.where(item == "Lamp" and cart == Cart.id).exists()
+      ).exists())
+  ).name == "John Doe"
 
 type
   TableQuery*[T] = object

--- a/src/ponairi/queryBuilder.nim
+++ b/src/ponairi/queryBuilder.nim
@@ -138,6 +138,14 @@ defineInfixOp(`==`, string, bool)
 defineInfixOp(`and`, bool, bool)
 defineInfixOp(`or`, bool, bool)
 
+func `==`*[T](a, b: QueryPart[Option[T]]): QueryPart[bool] =
+  ## Checks if two optional values are equal using SQLites `IS` operator.
+  ## This means that two `none(T)` or two `some(T)` (if value inside is the same) values are considered equal
+  result = QueryPart[bool](fmt"{a.string} IS {pattern.string}")
+
+func `not`*(expression: QueryPart[bool]): QueryPart[bool] =
+  result = QueryPart[bool](fmt"NOT ({expression.string})")
+
 func `~=`*(a, pattern: QueryPart[string]): QueryPart[bool] =
   ## Used for **LIKE** matches. The pattern can use two wildcards
   ##

--- a/src/ponairi/queryBuilder.nim
+++ b/src/ponairi/queryBuilder.nim
@@ -297,7 +297,12 @@ proc checkSymbols(node: NimNode, currentTable: NimNode, scope: seq[NimNode], par
         typ = param[1]
       else:
         usageMsg.error(node)
-      params &= repr typ
+      if pos == params.len:
+        params.insert(repr typ, pos)
+      elif pos > params.len:
+        "Invalid position for parameter".error(param)
+      elif repr(typ) != params[pos]:
+        fmt"Parameter at index {pos} is {params[pos]} but you tried to override with {typ}".error(param)
       result = initQueryPartNode(typ, "?" & $(pos + 1)) # SQLite parameters are 1 indexed
     else:
       for i in 1..<node.len: # We can ignore the first node, Nim will check it later

--- a/src/ponairi/queryBuilder.nim
+++ b/src/ponairi/queryBuilder.nim
@@ -5,9 +5,7 @@ import std/[
   options,
   typetraits,
   macrocache,
-  sugar,
   strutils,
-  genasts,
   sequtils
 ]
 
@@ -308,7 +306,7 @@ proc checkSymbols(node: NimNode, currentTable: NimNode, scope: seq[NimNode],
     else:
       let typ = currentTable.getType(node)
       if typ.isNone:
-        fmt"{node} doesn't exist in {currentTable}".error(node)
+        doesntExistErr($node, $currentTable).error(node)
       return initQueryPartNode(typ.unsafeGet, fmt"{currentTable.strVal}.{node.strVal}")
   of nnkStrLit:
     return initQueryPartNode(string, fmt"'{node.strVal}'")
@@ -461,7 +459,7 @@ proc checkFieldOrdering(x: typedesc, sortings: openArray[ColumnOrder]) {.compile
   for order in sortings:
     echo obj.hasProperty(order.column)
     if not obj.hasProperty(order.column):
-      fmt"{order.column} doesn't exist in {obj}".error(order.line)
+      doesntExistErr(order.column, obj).error(order.line)
 
     # Check if type can actually be nullable
     if order.order in {NullsFirst, NullsLast}:

--- a/src/ponairi/queryBuilder.nim
+++ b/src/ponairi/queryBuilder.nim
@@ -241,3 +241,10 @@ proc exists*[T](db; q: static[TableQuery[T]], args): bool =
     query = sql fmt"SELECT EXISTS (SELECT 1 FROM {table} WHERE {q.string} LIMIT 1)"
   db.getValue[:int64](query).unsafeGet() == 1
 
+proc delete*[T](db; q: static[TableQuery[T]], args) =
+  ## Deletes any row that matches the query
+  const
+    table = T.tableName
+    query = sql fmt"DELETE FROM {table} WHERE {q.string}"
+  db.exec(query)
+

--- a/src/ponairi/queryBuilder.nim
+++ b/src/ponairi/queryBuilder.nim
@@ -250,7 +250,8 @@ macro checkArgs(types: static[seq[string]], args: varargs[untyped]) =
     # We want the error message to point to where the user is calling the query so we need to set it.
     let info = args.lineInfoObj
     # Set the line info of the error pragma
-    foo[0][1][0][0].setLineInfo(args.lineInfoObj)
+    when declared(macros.setLineInfo):
+      foo[0][1][0][0].setLineInfo(args.lineInfoObj)
     result &= foo
 
 proc find[T](db; q: static[TableQuery[T]], args): T {.inline.} =

--- a/src/ponairi/queryBuilder.nim
+++ b/src/ponairi/queryBuilder.nim
@@ -45,12 +45,6 @@ template `..<`*(a, b: QueryPart[int]): HSlice[QueryPart[int], QueryPart[int]] =
   ## Overload for `..<` to work with `QueryPart[int]`
   a .. pred(b)
 
-func `and`*(a, b: QueryPart[bool]): QueryPart[bool] =
-  result = QueryPart[bool](fmt"({a.string} AND {b.string})")
-
-func `or`*(a, b: QueryPart[bool]): QueryPart[bool] =
-  result = QueryPart[bool](fmt"({a.string} OR {b.string})")
-
 macro opToStr(op: untyped): string = newLit op[0].strVal
 
 dumpAstGen:
@@ -59,7 +53,7 @@ dumpAstGen:
 template defineInfixOp(op, sideTypes, returnType: untyped) =
   ## Creates an infix operator which has **sideTypes** on both sides of the operation and returns **returnType**
   func op*(a, b: QueryPart[sideTypes]): QueryPart[returnType] =
-    result = QueryPart[returnType](a.string & " " & opToStr(op) & " " & b.string)
+    result = QueryPart[returnType](a.string & " " & toUpperAscii(opToStr(op)) & " " & b.string)
 
 defineInfixOp(`<`, int, bool)
 defineInfixOp(`>`, int, bool)

--- a/src/ponairi/queryBuilder.nim
+++ b/src/ponairi/queryBuilder.nim
@@ -126,6 +126,9 @@ type
     ## This is a component of a query, stores the type that the SQL would return
     ## and also the SQL that it is
 
+const inlineParam = "PONAIRI_INLINE_PARAM"
+  ## Sentinal value for when a parameter is provided inline and so we shouldn't expect a value
+
 func tableName[T](x: typedesc[T]): string =
   result = $T
 
@@ -285,6 +288,7 @@ proc checkSymbols(node: NimNode, currentTable: NimNode, scope: seq[NimNode],
   ## Converts atoms like literals (e.g. integer, string, bool literals) and symbols (e.g. properties in an object, columns in current scope)
   ## into [QueryPart] variables. This then allows us to leave the rest of the query parsing to the Nim compiler which means I don't need to
   ## reinvent the wheel with type checking.
+
   template checkAfter(start: int) =
     ## Checks the rest of the nodes starting with `start`
     for i in start..<node.len:
@@ -300,7 +304,6 @@ proc checkSymbols(node: NimNode, currentTable: NimNode, scope: seq[NimNode],
       if typ.isNone:
         fmt"{node} doesn't exist in {currentTable}".error(node)
       return initQueryPartNode(typ.unsafeGet, fmt"{currentTable.strVal}.{node.strVal}")
-
   of nnkStrLit:
     return initQueryPartNode(string, fmt"'{node.strVal}'")
   of nnkIntLit:

--- a/src/ponairi/utils.nim
+++ b/src/ponairi/utils.nim
@@ -1,4 +1,7 @@
-import macros
+import std/[
+  strformat,
+  macros
+]
 
 func seperateBy*[T](items: openArray[T], sep: string,
                    handler: proc (x: T): string): string {.effectsOf: handler.} =
@@ -25,3 +28,7 @@ template findIt*(s, pred: untyped): int =
   if result == s.len:
     result = -1
   result
+
+func doesntExistErr*(field, table: string): string =
+  ## Returns formatted error for when a field doesn't exist
+  fmt"{field} doesn't exist in {table}"

--- a/src/ponairi/utils.nim
+++ b/src/ponairi/utils.nim
@@ -1,3 +1,5 @@
+import macros
+
 func seperateBy*[T](items: openArray[T], sep: string,
                    handler: proc (x: T): string): string {.effectsOf: handler.} =
   ## Runs `handler` on every `item` and seperates all the items.
@@ -6,3 +8,9 @@ func seperateBy*[T](items: openArray[T], sep: string,
     result &= handler(items[i])
     if i < items.len - 1:
       result &= sep
+
+template currentLine*(): LineInfo =
+  ## Returns the current line as a LineInfo
+  block:
+    let pos = instantiationInfo(fullPaths = true)
+    LineInfo(filename: pos.filename, line: pos.line, column: pos.column)

--- a/src/ponairi/utils.nim
+++ b/src/ponairi/utils.nim
@@ -12,5 +12,5 @@ func seperateBy*[T](items: openArray[T], sep: string,
 template currentLine*(): LineInfo =
   ## Returns the current line as a LineInfo
   block:
-    let pos = instantiationInfo(fullPaths = true)
+    const pos = instantiationInfo(-2, fullPaths = true)
     LineInfo(filename: pos.filename, line: pos.line, column: pos.column)

--- a/src/ponairi/utils.nim
+++ b/src/ponairi/utils.nim
@@ -1,0 +1,8 @@
+func seperateBy*[T](items: openArray[T], sep: string,
+                   handler: proc (x: T): string): string {.effectsOf: handler.} =
+  ## Runs `handler` on every `item` and seperates all the items.
+  ## Doesn't add seperator to the end though
+  for i in 0..<items.len:
+    result &= handler(items[i])
+    if i < items.len - 1:
+      result &= sep

--- a/src/ponairi/utils.nim
+++ b/src/ponairi/utils.nim
@@ -11,6 +11,17 @@ func seperateBy*[T](items: openArray[T], sep: string,
 
 template currentLine*(): LineInfo =
   ## Returns the current line as a LineInfo
-  block:
-    const pos = instantiationInfo(-2, fullPaths = true)
-    LineInfo(filename: pos.filename, line: pos.line, column: pos.column)
+  const (filename, line, column) = instantiationInfo(-2, fullPaths = true)
+  LineInfo(filename: filename, line: line, column: column)
+
+template findIt*(s, pred: untyped): int =
+  ## Like `find` except you can pass a custom checker
+  var result = 0
+  for it {.inject.} in s:
+    if pred:
+      break
+    inc result
+  # Retain semantics that -1 means it couldn't find it
+  if result == s.len:
+    result = -1
+  result

--- a/src/ponairi/utils.nim
+++ b/src/ponairi/utils.nim
@@ -1,6 +1,7 @@
 import std/[
   strformat,
-  macros
+  macros,
+  strutils
 ]
 
 func seperateBy*[T](items: openArray[T], sep: string,
@@ -32,3 +33,11 @@ template findIt*(s, pred: untyped): int =
 func doesntExistErr*(field, table: string): string =
   ## Returns formatted error for when a field doesn't exist
   fmt"{field} doesn't exist in {table}"
+
+func escapeQuoteSQL*(x: string): string =
+  ## Escapes quotes (') in a string so that SQLite will treat them as a character
+  runnableExamples:
+    assert "Hello 'world'".escapeQuoteSQL() == "Hello ''world''"
+  #==#
+  x.replace("'", "''")
+

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,1 +1,3 @@
 testAll
+testMacros
+megatest*

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,3 +1,4 @@
 testAll
 testMacros
 megatest*
+errorChecker

--- a/tests/data.nim
+++ b/tests/data.nim
@@ -1,0 +1,60 @@
+## Stores all the data for our tess
+
+import ../src/ponairi
+import std/[
+  options,
+  strformat
+]
+
+when (NimMajor, NimMinor) < (1, 7):
+  {.experimental: "overloadableEnums".}
+
+type
+  Status* = enum
+    Alive
+    Dead
+    Undead # Our schema supports zombie apocalypse
+
+  Person* {.table.} = object
+    name* {.primary.}: string
+    age*: int
+    status*: Status
+    extraInfo*: Option[string]
+
+  Dog* {.table.} = ref object
+    name* {.primary.}: string
+    owner* {.references(Person.name), cascade.}: string
+
+  Something* {.table.} = object
+    name*, age*: string
+    another* {.references: Person.name, cascade.}: string
+    price*: float
+
+func `$`*(d: Dog): string =
+  if d != nil:
+    fmt"{d.name} -> {d.owner}"
+  else:
+    "nil"
+
+func `==`*(a, b: Dog): bool =
+  a.name == b.name and a.owner == b.owner
+
+
+const
+  jake* = Person(name: "Jake", age: 42, status: Alive)
+  john* = Person(name: "John", age: 45, status: Dead, extraInfo: some "Test")
+  people* = [jake, john]
+  everybody* = seq[Person].where(1 == 1)
+
+
+proc `<`*(a, b: Person): bool =
+  a.age < b.age
+
+let jakesDogs* = [
+  Dog(owner: "Jake", name: "Dog"),
+  Dog(owner: "Jake", name: "Bark"),
+  Dog(owner: "Jake", name: "Woof"),
+  Dog(owner: "Jake", name: "something")
+]
+
+export ponairi

--- a/tests/data.nim
+++ b/tests/data.nim
@@ -3,7 +3,8 @@
 import ../src/ponairi
 import std/[
   options,
-  strformat
+  strformat,
+  times
 ]
 
 when (NimMajor, NimMinor) < (1, 7):
@@ -24,6 +25,7 @@ type
   Dog* {.table.} = ref object
     name* {.primary.}: string
     owner* {.references(Person.name), cascade.}: string
+    other: Option[DateTime]
 
   Something* {.table.} = object
     name*, age*: string

--- a/tests/errorChecker.nim
+++ b/tests/errorChecker.nim
@@ -1,0 +1,169 @@
+##[
+  Simple program to run a file and check errors are in the right file/column/line.
+  This uses similar syntax to testament for specifying errors (Except no need for the tt. prefix).
+  ```nim
+  discard true == 9 #[Error
+               ^ type mistmatch]#
+  ```
+  This was built since testament had some issues when trying to check multiple errors (the template/generic instatiation broke it).
+  I didn't know enough about testament to write a PR, and I think it might be intended behaviour
+]##
+
+import std/[
+  os,
+  strutils,
+  strformat,
+  osproc,
+  tables,
+  strscans,
+  sets,
+  macros,
+  sugar,
+  terminal
+]
+
+import ponairi/utils
+
+type
+  TestKind = enum # TODO: Support warnings and hints
+    Error
+
+  Test = object
+    kind: TestKind
+    message: string
+    file: string
+    line, column: int
+
+  ResultKind = enum
+    Passed
+    LineWrong
+    ColumnWrong
+    MessageWrong
+    FileWrong
+    NotFound
+
+  TestResult = object
+    test: Test
+    case result: ResultKind
+    of Passed, NotFound: discard
+    of FileWrong:
+      loc: LineInfo
+    of LineWrong:
+      line: int
+    of ColumnWrong:
+      column: int
+    of MessageWrong:
+      message: string
+
+proc parseTests(file: string): seq[Test] =
+  ## Parses all the tests in a file. Uses similar syntax to testament
+  runnableExamples:
+    # We drop the tt. prefix
+    # Rest is the same
+    discard someProc(9 + true) #[Error
+                       ^ type mismatch]#
+  #==#
+  var
+    findCarat = false # In finding carat state
+    test: Test
+    lineNum = 1# Current line in file
+  for line in file.lines:
+    if findCarat:
+      # Find the carlineat that specifies where the column is and then add the test
+      let column = line.find("^")
+      if column == -1:
+        raise (ref CatchableError)(msg: fmt"Couldn't find carat for {file.extractFileName()}:{lineNum}")
+      test.message = line[column + 1 .. ^3].strip() # Remove the ]# from the end
+      test.column = column + 1
+      result &= test
+      findCarat = false
+    elif line.endsWith("#[Error"):
+      findCarat = true
+      test.file = file
+      test.line = lineNum
+      test.kind = Error
+    lineNum += 1
+
+iterator parseErrors(process: Process): Test =
+  ## Returns all the errors from the output
+  for line in process.lines:
+    var test: Test
+    if line.scanf("$+($i, $i) Error: $+$.", test.file, test.line, test.column, test.message):
+      yield test
+
+var files: seq[string]
+# Build list of files that we will parse.
+# We allow the use of patterns
+for pattern in commandLineParams():
+  for file in walkFiles(pattern):
+    files &= file
+
+var results = newSeq[seq[TestResult]](files.len)
+
+proc handleFile(idx: int, process: Process) =
+  ## Handles testing the output of a check. Puts the result in `results`
+  var tests = files[idx].parseTests()
+  for error in process.parseErrors:
+    # Try and find the error first by message. Then try line/file if we can't find it.
+    # This is done since sometimes the message might be there but be in the wrong file
+    var i = tests.findIt(it.message == error.message)
+    if i == -1:
+      i = tests.findIt(it.file == error.file and it.line == error.line)
+    # We found it, check it all lines up
+    if i != -1:
+      var res: TestResult
+      let test = tests[i]
+      if not test.file.sameFile(error.file):
+        res = TestResult(result: FileWrong, loc: LineInfo(filename: error.file, line: error.line, column: error.column))
+      elif test.line != error.line:
+        res = TestResult(result: LineWrong, line: error.line)
+      elif test.column != error.column:
+        res = TestResult(result: ColumnWrong, column: error.column)
+      elif test.message != error.message:
+        res = TestResult(result: MessageWrong, message: error.message)
+      else:
+        res = TestResult(result: Passed)
+      res.test = test
+      results[idx] &= res
+      tests.del(i) # Ignore the test after this
+  # Any left over tests will fail since the error wasn't found
+  results[idx].add collect do:
+    for test in tests:
+      TestResult(test: test, result: NotFound)
+
+# Run the checks in parallel. We collect the results and output them after
+let commands = collect:
+  for file in files:
+    fmt"nim check '{file}'"
+
+discard execProcesses(commands, options = {poStdErrToStdOut, poUsePath}, afterRunEvent = handleFile)
+
+var
+  passed = 0
+  total = 0
+
+for i in 0..<results.len:
+  let file = files[i]
+  stdout.styledWriteLine(fgBlue, file, resetStyle)
+  for result in results[i]:
+    let test = result.test
+    stdout.write("  " & result.test.message & ": ")
+    total += 1
+    case result.result
+    of Passed:
+      stdout.styledWriteLine(fgGreen, "Passed", resetStyle)
+      passed += 1
+    of LineWrong:
+      stdout.styledWriteLine(fgRed, fmt"Expected line {test.line} but got {result.line}", resetStyle)
+    of ColumnWrong:
+      stdout.styledWriteLine(fgRed, fmt"Expected column {test.column} but got {result.column}", resetStyle)
+    of FileWrong:
+      stdout.styledWriteLine(fgRed, fmt"Expected error at {test.file}:({test.line}, {test.column}) but got {result.loc}", resetStyle)
+    of MessageWrong:
+      stdout.styledWriteLine(fgRed, fmt"Got '{result.message}'", resetStyle)
+    of NotFound:
+      stdout.styledWriteLine(fgRed, "Not found", resetStyle)
+
+echo fmt"{passed}/{total} passed"
+
+quit(if passed == total: QuitSuccess else: QuitFailure)

--- a/tests/errors/tNonExistantField.nim
+++ b/tests/errors/tNonExistantField.nim
@@ -1,18 +1,14 @@
-discard """
-cmd: "nim check $file"
-"""
-
 import ../data
 
 var db: DbConn
 
-discard Person.where(unknown == "test") #[tt.Error
+discard Person.where(unknown == "test") #[Error
                      ^ unknown doesn't exist in Person]#
 
-discard db.find(everybody.orderBy([asc test])) #[tt.Error
+discard db.find(everybody.orderBy([asc test])) #[Error
                                        ^ test doesn't exist in Person]#
 
 Person.where(
-  exists(Dog.where(owner == Person.owner)) #[tt.Error
+  exists(Dog.where(owner == Person.owner)) #[Error
                                    ^ owner doesn't exist in Person]#
 )

--- a/tests/errors/tNonExistantField.nim
+++ b/tests/errors/tNonExistantField.nim
@@ -1,0 +1,18 @@
+discard """
+cmd: "nim check $file"
+"""
+
+import ../data
+
+var db: DbConn
+
+discard Person.where(unknown == "test") #[tt.Error
+                     ^ unknown doesn't exist in Person]#
+
+discard db.find(everybody.orderBy([asc test])) #[tt.Error
+                                       ^ test doesn't exist in Person]#
+
+Person.where(
+  exists(Dog.where(owner == Person.owner)) #[tt.Error
+                                   ^ owner doesn't exist in Person]#
+)

--- a/tests/errors/tNonExistantField.nim
+++ b/tests/errors/tNonExistantField.nim
@@ -12,3 +12,6 @@ Person.where(
   exists(Dog.where(owner == Person.owner)) #[Error
                                    ^ owner doesn't exist in Person]#
 )
+
+db.upsert(jake, test) #[Error
+                ^ test doesn't exist in Person]#

--- a/tests/errors/tOrderings.nim
+++ b/tests/errors/tOrderings.nim
@@ -1,0 +1,8 @@
+discard """
+cmd: "nim check $file"
+"""
+import ../data
+var db: DbConn
+
+discard db.find(everybody.orderBy([nullsFirst name])) #[tt.Error
+                                              ^ name is not nullable]#

--- a/tests/errors/tOrderings.nim
+++ b/tests/errors/tOrderings.nim
@@ -1,8 +1,5 @@
-discard """
-cmd: "nim check $file"
-"""
 import ../data
 var db: DbConn
 
-discard db.find(everybody.orderBy([nullsFirst name])) #[tt.Error
+discard db.find(everybody.orderBy([nullsFirst name])) #[Error
                                               ^ name is not nullable]#

--- a/tests/errors/tParamTypeMismatch.nim
+++ b/tests/errors/tParamTypeMismatch.nim
@@ -1,0 +1,7 @@
+import ../data
+
+var db: DbConn
+
+let num = 9
+db.find(Person.where(name == {num})) #[Error
+                          ^ type mismatch]#

--- a/tests/errors/tScopeErrors.nim
+++ b/tests/errors/tScopeErrors.nim
@@ -1,0 +1,9 @@
+discard """
+cmd: "nim check $file"
+"""
+import ../data
+var db: DbConn
+
+
+Person.where(Dog.name == "test") #[tt.Error
+             ^ Dog is not currently accessible]#

--- a/tests/errors/tScopeErrors.nim
+++ b/tests/errors/tScopeErrors.nim
@@ -1,9 +1,6 @@
-discard """
-cmd: "nim check $file"
-"""
 import ../data
 var db: DbConn
 
 
-Person.where(Dog.name == "test") #[tt.Error
+Person.where(Dog.name == "test") #[Error
              ^ Dog is not currently accessible]#

--- a/tests/errors/tTypeErrors.nim
+++ b/tests/errors/tTypeErrors.nim
@@ -1,0 +1,17 @@
+discard """
+cmd: "nim check $file"
+"""
+
+import ../data
+
+var db: DbConn
+
+
+
+Person.where(name == 9) #[tt.Error
+                  ^ type mismatch]#
+
+let num = 9
+db.find(Person.where(name == {num})) #[tt.Error
+                          ^ type mismatch]#
+

--- a/tests/errors/tTypeErrors.nim
+++ b/tests/errors/tTypeErrors.nim
@@ -4,7 +4,7 @@ var db: DbConn
 
 
 discard db.find(Person.where(1 + 1)) #[Error
-                               ^ Query should return 'bool']#
+                               ^ Query must return 'bool']#
 
 Person.where(name == 9) #[Error
                   ^ type mismatch]#

--- a/tests/errors/tTypeErrors.nim
+++ b/tests/errors/tTypeErrors.nim
@@ -1,17 +1,14 @@
-discard """
-cmd: "nim check $file"
-"""
-
 import ../data
 
 var db: DbConn
 
 
+discard db.find(Person.where(1 + 1)) #[Error
+                               ^ Query should return 'bool']#
 
-Person.where(name == 9) #[tt.Error
+Person.where(name == 9) #[Error
                   ^ type mismatch]#
 
-let num = 9
-db.find(Person.where(name == {num})) #[tt.Error
-                          ^ type mismatch]#
+
+
 

--- a/tests/testAll.nim
+++ b/tests/testAll.nim
@@ -3,7 +3,9 @@ import std/[
   options,
   times,
   strformat,
-  algorithm
+  algorithm,
+  strutils,
+  times
 ]
 import data
 import ponairi

--- a/tests/testAll.nim
+++ b/tests/testAll.nim
@@ -148,8 +148,10 @@ suite "Base API":
 
 suite "Query builder":
   let db = newConn(":memory:")
-  db.create(Person)
+  db.create(Person, Dog)
   db.insert(people)
+  db.insert(jakesDogs)
+
   test "Find one":
     check db.find(Person.where(name == "Jake")) == jake
 
@@ -159,3 +161,4 @@ suite "Query builder":
   test "Exists":
     check db.exists(Person.where(name == "Jake"))
     check not db.exists(Person.where(age < 10))
+

--- a/tests/testAll.nim
+++ b/tests/testAll.nim
@@ -303,3 +303,7 @@ suite "Query builder":
     check compiles(everybody().orderBy(Ascending age))
     check compiles(everybody().orderBy(age.Ascending))
     check compiles(everybody().orderBy(age.Ascending()))
+
+  test "Multiple orderings can be passed":
+    # More just checking the query actually runs, I trust sqlite to work
+    discard db.find everybody().orderBy(Ascending(age), Descending(name))

--- a/tests/testAll.nim
+++ b/tests/testAll.nim
@@ -236,4 +236,4 @@ suite "Query builder":
   test "Parameters":
     check db.find(Person.where(name == ?string), "Jake") == jake
     check db.find(Person.where(name == ?[1, string]), "Jake") == jake
-
+    check db.find(Person.where(age == ?[1, int]), 42) == jake

--- a/tests/testAll.nim
+++ b/tests/testAll.nim
@@ -237,3 +237,8 @@ suite "Query builder":
     check db.find(Person.where(name == ?string), "Jake") == jake
     check db.find(Person.where(name == ?[1, string]), "Jake") == jake
     check db.find(Person.where(age == ?[1, int]), 42) == jake
+
+  test "Can delete":
+    db.delete(Person.where(age == 42))
+    check db.find(seq[Person]) == @[john]
+    db.insert(jake)

--- a/tests/testAll.nim
+++ b/tests/testAll.nim
@@ -232,7 +232,9 @@ suite "Query builder":
     check db.find(seq[Person].where(extraInfo.isNone())) == @[john]
 
   test "Inside array":
-    check db.find(seq[Person].where(age in [42, 45, 46])) == people
+    const query = seq[Person].where(age in [42, 45, 46])
+    check query.sql == "Person.age IN (42, 45, 46)"
+    check db.find(query) == people
 
   test "In range":
     check db.find(seq[Person].where(age in 0..<45)) == @[jake]
@@ -269,6 +271,12 @@ suite "Query builder":
     db.delete(Person.where(age == 42))
     check db.find(seq[Person]) == @[john]
     db.insert(jake)
+
+  test "Can get default value for option":
+    check db.find(
+      Person.where(name == ?string and extraInfo.get("Some value") == ?string),
+      "Jake", "Some value"
+    ) == jake
 
   template everybody(): TableQuery = seq[Person].where()
   test "Can set order of query":

--- a/tests/testAll.nim
+++ b/tests/testAll.nim
@@ -7,6 +7,9 @@ import std/[
 ]
 import ponairi
 
+when (NimMajor, NimMinor) < (1, 7):
+  {.experimental: "overloadableEnums".}
+
 type
   Status = enum
     Alive

--- a/tests/testAll.nim
+++ b/tests/testAll.nim
@@ -25,6 +25,7 @@ type
   Something* = object
     name*, age*: string
     another {.references: Person.name, cascade.}: string
+    price: float
 
 func `$`(d: Dog): string =
   if d != nil:

--- a/tests/testAll.nim
+++ b/tests/testAll.nim
@@ -273,3 +273,8 @@ suite "Query builder":
         check db.find(query) == person
         check db.exists(query)
     test()
+
+  test "Works with proc parameters":
+    proc test(db: DbConn, name: string) =
+      check db.exists(Person.where(name == {name}))
+    db.test(jake.name)

--- a/tests/testAll.nim
+++ b/tests/testAll.nim
@@ -235,10 +235,17 @@ suite "Query builder":
 
   test "Parameters":
     check db.find(Person.where(name == ?string), "Jake") == jake
-    check db.find(Person.where(name == ?[1, string]), "Jake") == jake
-    check db.find(Person.where(age == ?[1, int]), 42) == jake
+    check db.find(Person.where(name == ?[0, string]), "Jake") == jake
+    check db.find(Person.where(age == ?[0, int] and name == "Jake"), 42) == jake
+
+  test "Type mismatches don't compile":
+    check not compiles(db.find(Person.where(name == ?string), 9))
+
+  test "Mismatched amount of parameters don't compile":
+    check not compiles(db.find(Person.where(name == ?string and name == ?int)))
 
   test "Can delete":
     db.delete(Person.where(age == 42))
     check db.find(seq[Person]) == @[john]
     db.insert(jake)
+

--- a/tests/testAll.nim
+++ b/tests/testAll.nim
@@ -4,7 +4,7 @@ import std/[
   times,
   strformat
 ]
-import ponairi {.all.}
+import ponairi
 
 type
   Status = enum

--- a/tests/testAll.nim
+++ b/tests/testAll.nim
@@ -74,10 +74,6 @@ suite "Base API":
     check dog in db.find(seq[Dog])
     db.upsert(oldVal)
 
-  test "Upsert check fields exist":
-    # This isn't in testament tests since it kept getting the file wrong
-    check not compiles(db.upsert(jake, test))
-
   test "Finding to tuples":
     let pairs = db.find(seq[tuple[owner: string, dog: string]], sql"SELECT Person.name, Dog.name FROM Dog JOIN Person ON Person.name = Dog.owner ")
     for row in pairs:

--- a/tests/testAll.nim
+++ b/tests/testAll.nim
@@ -289,11 +289,12 @@ suite "Query builder":
       .find(everybody().orderBy(nullsLast extraInfo))[0]
       .extraInfo.isSome()
 
-  test "Can only use null order on nullable column":
-    check not compiles(everybody().orderBy(nullsFirst age))
+  when false: # TODO: Run these tests with testament.
+    test "Can only use null order on nullable column":
+      check not compiles(everybody().orderBy(nullsFirst age))
 
-  test "orderBy checks column exists":
-    check not compiles(everybody().orderBy(desc notFound))
+    test "orderBy checks column exists":
+      check not compiles(everybody().orderBy(desc notFound))
 
   test "Multiple orderings can be passed":
     # More just checking the query actually runs, I trust sqlite to work

--- a/tests/testAll.nim
+++ b/tests/testAll.nim
@@ -180,3 +180,7 @@ suite "Query builder":
     check not compiles(Person.where(
       exists(Dog.where(owner == Person.owner))
     ))
+
+  test "Can only access tables that are in scope":
+    check not compiles(Person.where(Dog.name == "test"))
+

--- a/tests/testAll.nim
+++ b/tests/testAll.nim
@@ -212,3 +212,8 @@ suite "Query builder":
   test "Can only access tables that are in scope":
     check not compiles(Person.where(Dog.name == "test"))
 
+  test "Can access outer table in inner call":
+    check db.find(seq[Person].where(
+      exists(Dog.where(owner == Person.name))
+    )) == @[jake]
+

--- a/tests/testAll.nim
+++ b/tests/testAll.nim
@@ -277,3 +277,10 @@ suite "Query builder":
 
   test "Works with prefix calls":
     discard db.exists(Person.where(not extraInfo.isSome()))
+
+  # test "Calls can be composed":
+  #   var foo = 9 # TODO: Add place holder syntax like {foo: int} for when it doesn't exist in scope of declaration'
+  #   const peeps = Person.where(age == {foo})
+  #   proc test() =
+  #     foo = jake.age
+  #     check db.find(Person.where(name == {jake.age} and exists(peeps)))

--- a/tests/testAll.nim
+++ b/tests/testAll.nim
@@ -241,7 +241,10 @@ suite "Query builder":
 
   test "Parameters can reuse numbers":
     check db.find(Person.where(name == ?[0, string] and name == ?[0, string]), "Jake") == jake
-
+    check db.find(Person.where(
+      name == ?[0, string] and age == ?[1, int] and
+      name == ?[0, string] and age == ?[1, int]
+    ), "Jake", 42) == jake
   test "Error if parameter is jumping too far ahead":
     check not compiles(Person.where(name == ?[1, string]))
 

--- a/tests/testAll.nim
+++ b/tests/testAll.nim
@@ -219,3 +219,13 @@ suite "Query builder":
 
   test "Types are checked":
     check not compiles(db.find(Person.where(name == 9)))
+
+  test "Can perform nil checks":
+    check db.find(seq[Person].where(extraInfo.isSome)) == @[jake]
+    check db.find(seq[Person].where(extraInfo.isNone())) == @[john]
+
+  test "Inside array":
+    check db.find(seq[Person].where(age in [42, 45, 46])) == people
+
+  test "In range":
+    check db.find(seq[Person].where(age in 0..<45)) == @[jake]

--- a/tests/testAll.nim
+++ b/tests/testAll.nim
@@ -246,3 +246,30 @@ suite "Query builder":
       discard x
     foo:
       db.find(Person.where())
+
+  test "Works inside a proc":
+    # Was running into a environment misses issue.
+    # Issue was that I was building the parameters inside the find proc and so it couldn't access the outside scope.
+    # worked in some circumstances since it could access global variables
+    proc test() =
+      let name = jake.name
+      const query = Person.where(name == {name})
+      check db.find(query) == jake
+      check db.exists(query)
+      db.delete(query)
+      db.insert jake
+    test()
+
+  test "Has environment inside iterator":
+    proc test() =
+      for person in people:
+        check db.exists(Person.where(name == {person.name}))
+    test()
+
+  test "Works with lent[T]":
+    proc test() =
+      for person in @people:
+        const query = Person.where(name == {person.name})
+        check db.find(query) == person
+        check db.exists(query)
+    test()

--- a/tests/testAll.nim
+++ b/tests/testAll.nim
@@ -232,3 +232,8 @@ suite "Query builder":
 
   test "Pattern matching":
     check db.find(seq[Person].where(name ~= "%Ja%")) == @[jake]
+
+  test "Parameters":
+    check db.find(Person.where(name == ?string), "Jake") == jake
+    check db.find(Person.where(name == ?[1, string]), "Jake") == jake
+

--- a/tests/testAll.nim
+++ b/tests/testAll.nim
@@ -307,6 +307,10 @@ suite "Query builder":
   test "Multiple orderings can be passed":
     # More just checking the query actually runs, I trust sqlite to work
     discard db.find everybody().orderBy(asc age, desc name)
+    let name = "test"
+    discard db.find(
+      Person.where(name == {name})
+    )
 
   test "Works in overloaded templates":
     # This was a weird bug I found which was causing problems when used in async (Due to a feature I implemented funnyily enough)

--- a/tests/testAll.nim
+++ b/tests/testAll.nim
@@ -299,3 +299,16 @@ suite "Query builder":
   test "Multiple orderings can be passed":
     # More just checking the query actually runs, I trust sqlite to work
     discard db.find everybody().orderBy(asc age, desc name)
+
+  test "Works in overloaded templates":
+    # This was a weird bug I found which was causing problems when used in async (Due to a feature I implemented funnyily enough)
+    # Not an issue with async, but for some reason overloaded templates in general caused issues.
+    #
+    # For future reference in case this ever pops up again:
+    # The problem was me assigning the query to a temporary const, not doing that fixed it (Guessing it was some weird sem matching problem)
+    template foo(x: string) =
+      echo x
+    template foo(x: untyped) =
+      discard x
+    foo:
+      db.find(Person.where())

--- a/tests/testAll.nim
+++ b/tests/testAll.nim
@@ -273,40 +273,28 @@ suite "Query builder":
   template everybody(): TableQuery = seq[Person].where()
   test "Can set order of query":
     check db
-      .find(everybody().orderBy(Ascending(age)))
+      .find(everybody().orderBy(asc age))
       .isSorted(Ascending)
 
     check db
-      .find(everybody().orderBy(Descending(age)))
+      .find(everybody().orderBy(desc age))
       .isSorted(Descending)
 
   test "Can set null order":
     check db
-      .find(everybody().orderBy(NullsFirst(extraInfo)))[0]
+      .find(everybody().orderBy(nullsFirst extraInfo))[0]
       .extraInfo.isNone()
 
     check db
-      .find(everybody().orderBy(NullsLast(extraInfo)))[0]
+      .find(everybody().orderBy(nullsLast extraInfo))[0]
       .extraInfo.isSome()
 
   test "Can only use null order on nullable column":
-    check not compiles(everybody().orderBy(NullsFirst(age)))
+    check not compiles(everybody().orderBy(nullsFirst age))
 
   test "orderBy checks column exists":
-    check not compiles(everybody().orderBy(Descending(notFound)))
-
-  test "Test different order call methods":
-    check not compiles(everybody().orderBy(something))
-    check not compiles(everybody().orderBy(Null(age)))
-    check not compiles(everybody().orderBy(Last()))
-    check not compiles(everybody().orderBy(NullsFirst))
-    check not compiles(everybody().orderBy(NullsFirst()))
-
-    check compiles(everybody().orderBy(Ascending(age)))
-    check compiles(everybody().orderBy(Ascending age))
-    check compiles(everybody().orderBy(age.Ascending))
-    check compiles(everybody().orderBy(age.Ascending()))
+    check not compiles(everybody().orderBy(desc notFound))
 
   test "Multiple orderings can be passed":
     # More just checking the query actually runs, I trust sqlite to work
-    discard db.find everybody().orderBy(Ascending(age), Descending(name))
+    discard db.find everybody().orderBy(asc age, desc name)

--- a/tests/testAll.nim
+++ b/tests/testAll.nim
@@ -229,3 +229,6 @@ suite "Query builder":
 
   test "In range":
     check db.find(seq[Person].where(age in 0..<45)) == @[jake]
+
+  test "Pattern matching":
+    check db.find(seq[Person].where(name ~= "%Ja%")) == @[jake]

--- a/tests/testAll.nim
+++ b/tests/testAll.nim
@@ -239,6 +239,17 @@ suite "Query builder":
     check db.find(Person.where(name == ?[0, string]), "Jake") == jake
     check db.find(Person.where(age == ?[0, int] and name == "Jake"), 42) == jake
 
+  test "Parameters can reuse numbers":
+    check db.find(Person.where(name == ?[0, string] and name == ?[0, string]), "Jake") == jake
+
+  test "Error if parameter is jumping too far ahead":
+    check not compiles(Person.where(name == ?[1, string]))
+
+  test "Error if parameter type doesn't line up":
+    # Don't know why someone would do this
+    # But I'm probably going to do it so best to check lol
+    check not compiles(Person.where(name == ?string and age == ?[0, int]))
+
   test "Type mismatches don't compile":
     check not compiles(db.find(Person.where(name == ?string), 9))
 

--- a/tests/testAll.nim
+++ b/tests/testAll.nim
@@ -207,7 +207,7 @@ suite "Query builder":
 
   test "Can get default value for option":
     check db.find(
-      Person.where(name == {"Jake"} and extraInfo.get("Some value") == {"Some value"})
+      Person.where(name == "Jake" and extraInfo.get("Some value") == "Some value")
     ) == jake
 
   const everybody = seq[Person].where()
@@ -278,3 +278,6 @@ suite "Query builder":
     proc test(db: DbConn, name: string) =
       check db.exists(Person.where(name == {name}))
     db.test(jake.name)
+
+  test "Works with prefix calls":
+    discard db.exists(Person.where(not extraInfo.isSome()))

--- a/tests/testAll.nim
+++ b/tests/testAll.nim
@@ -217,3 +217,5 @@ suite "Query builder":
       exists(Dog.where(owner == Person.name))
     )) == @[jake]
 
+  test "Types are checked":
+    check not compiles(db.find(Person.where(name == 9)))

--- a/tests/testAll.nim
+++ b/tests/testAll.nim
@@ -168,3 +168,15 @@ suite "Query builder":
     check db.exists(Person.where(name == "Jake"))
     check not db.exists(Person.where(age < 10))
 
+  test "Inner SQL exists":
+    check db.exists(Person.where(
+      exists(Dog.where(owner == "Jake")))
+    )
+
+  test "Can't use property that doesn't exist":
+    check not compiles(Person.where(unknown == "test"))
+
+  test "Scope changes when directly accessing table":
+    check not compiles(Person.where(
+      exists(Dog.where(owner == Person.owner))
+    ))


### PR DESCRIPTION
Adds in a fully typesafe API for generating queries 

```nim
type
  Person = object
    name: string
    age: int

let db = newConn(":memory:")
db.create(Person)
# Error since name is a string and not an int
db.find(Person.where(name == 9))
# Type mismatch + not enough arguments
db.find(Person.where(name == ?int)) # Parameters now need to have their types declared
# The query is correct, but passing 9 is wrong since it expects a string for the first parameter
db.find(Person.where(name == ?string), 9)
```

Basically any SQL is possible as long as it only occurs in the `WHERE` clause

Extending the schema before I can show an example of a more complex query
```nim
type
  Person = object
    name {.primary.}: string
    age: int
  
  Item = object
    id {.primary, autoIncrement.}: int
    name: string
    price: int
    owner: Person

# Find every person that owns an item and is older than 42
echo db.find(seq[Person].where(
  exists(Item.where(owner == Person.name)) and age > 42
))

# Tables in scope is tracked so this wouldn't compile since there is no way to access Person
echo db.find(Item.where(owner == Person.name))
```

The system works via `QueryPart[T]` which is a distinct string that stores the type of the SQL string it holds. There is some macro magic to convert literals, columns, and parameters into `QueryPart[T]` but once that is finished everything else can be implemented without macros

An example is the modulo operator which could be implemented like so
```nim
# We restrict it to only work with integers
func `mod`[T: SomeInteger](a, b: T): T  {.importSQL: "$# % $#".}

# Or if written manually
func `mod`[T: SomeInteger](a, b: QueryPart[T]): QueryPart[T] =
  # Implementing is basically just joining strings together to form the SQL
  result = QueryPart[T](fmt"{a.string} % {b.string}")
```