### PR TITLE
Tuples with joins

### DIFF
--- a/tests/testAll.nim
+++ b/tests/testAll.nim
@@ -167,13 +167,14 @@ test "Exists without primary key":
   db.insert(item)
   check db.exists(item)
 
+# Allow find to work for next test
+proc `==`(b: (Dog, string), d: Dog): bool = d == b[0]
+
 test "Tuples to handle joins":
   # This is from a good example brought up by enthus1ast that I thought I supported but not well enough.
   # This checks the syntax from his example works (Which I found to be good syntax)
-  const query = "SELECT Dog.*, Person.name FROM Dog JOIN Person ON Person.name = Dog.owner"
+  const query = sql"SELECT Dog.*, Person.name FROM Dog JOIN Person ON Person.name = Dog.owner"
   let results = db.find(seq[(Dog, string)], query)
-
-  func `==`(d: Dog, b: (Dog, string)): bool = d == b[0]
 
   for dog in jakesDogs:
     let index = results.find(dog)

--- a/tests/testAll.nim
+++ b/tests/testAll.nim
@@ -167,4 +167,18 @@ test "Exists without primary key":
   db.insert(item)
   check db.exists(item)
 
+test "Tuples to handle joins":
+  # This is from a good example brought up by enthus1ast that I thought I supported but not well enough.
+  # This checks the syntax from his example works (Which I found to be good syntax)
+  const query = "SELECT Dog.*, Person.name FROM Dog JOIN Person ON Person.name = Dog.owner"
+  let results = db.find(seq[(Dog, string)], query)
+
+  func `==`(d: Dog, b: (Dog, string)): bool = d == b[0]
+
+  for dog in jakesDogs:
+    let index = results.find(dog)
+    check index != -1
+    if index != -1:
+      check results[index][1] == "Jake"
+
 close db


### PR DESCRIPTION
Was shown a good example by enthus1ast in the Nim discord about tuples with objects inside them to make JOINs work better. 

Turns out the tuple support wasn't that good so I've made it work to that level in this PR
```nim
const query = sql"SELECT Dog.*, Person.name FROM Dog JOIN Person ON Person.name = Dog.owner"
# The tuple values must line up with the query
let results = db.find(seq[(Dog, string)], query)
```