### PR TITLE
Transaction template

### DIFF
--- a/src/ponairi.nim
+++ b/src/ponairi.nim
@@ -207,7 +207,7 @@ proc commit*(db) =
   ## Commits a transaction
   db.exec(sql"COMMIT")
 
-template transaction(db; body: untyped) =
+template transaction*(db; body: untyped) =
   ## Runs the body in a transaction.
   ## If any error happens then it rolls back the transaction
   db.startTransaction()

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,1 +1,2 @@
 testAll
+testMacros

--- a/tests/testAll.nim
+++ b/tests/testAll.nim
@@ -182,4 +182,17 @@ test "Tuples to handle joins":
     if index != -1:
       check results[index][1] == "Jake"
 
+test "Transaction template":
+  var thrown = false
+  let garry = Person(name: "Garry", age: 101, status: Alive)
+  try:
+    db.transaction:
+      db.insert garry
+      raise (ref CatchableError)()
+  except CatchableError:
+    thrown = true
+
+  check thrown
+  check not db.exists garry
+
 close db


### PR DESCRIPTION
Forgot to make the transaction template public

This allows for running a series of statements in a transaction and automatically committing if nothing went wrong (And rolling back if an exception is thrown)

```nim
db.transaction:
  db.insert item1
  db.insert item2
  # Items wont be saved since this errors.
  # If it didn't error then they would be saved
  someFuncThatErrors()
```