### PR TITLE
Add support for indexes

### DIFF
--- a/src/ponairi/macroUtils.nim
+++ b/src/ponairi/macroUtils.nim
@@ -49,6 +49,7 @@ func `[]`*(items: seq[Pragma], name: string): Pragma =
   for item in items:
     if item.name.eqIdent(name): return item
 
+
 proc getName*(n: NimNode): string =
   case n.kind
   of nnkIdent, nnkSym:

--- a/src/ponairi/pragmas.nim
+++ b/src/ponairi/pragmas.nim
@@ -29,3 +29,21 @@ template references*(column: untyped) {.pragma.}
 
 template cascade*() {.pragma.}
   ## Turns on cascade deletion for a foreign key reference
+
+template index*(name = "") {.pragma.}
+  ##[
+    Creates an [index](https://www.sqlite.org/lang_createindex.html). If no name is given then it generates
+    an index that is only used for that column but a name can be given
+    to make an index be shared across multiple columns
+    
+    .. note:: All indexes will be prefixed with the table name to avoid collisions
+    
+    ```nim
+    type 
+      Model = object
+        title {.index.}: string # Index is made that is only used by title
+        # Make an index that is shared
+        tag {.index: "extra".}: string
+        info {.index: "extra".}: string
+    ```
+  ]##

--- a/src/ponairi/pragmas.nim
+++ b/src/ponairi/pragmas.nim
@@ -35,15 +35,21 @@ template index*(name = "") {.pragma.}
     Creates an [index](https://www.sqlite.org/lang_createindex.html). If no name is given then it generates
     an index that is only used for that column but a name can be given
     to make an index be shared across multiple columns
-    
+
     .. note:: All indexes will be prefixed with the table name to avoid collisions
-    
+
     ```nim
-    type 
+    type
       Model = object
         title {.index.}: string # Index is made that is only used by title
         # Make an index that is shared
         tag {.index: "extra".}: string
         info {.index: "extra".}: string
     ```
+  ]##
+
+template uniqueIndex*(name = "") {.pragma.}
+  ##[
+    Creates an [unique index](https://www.sqlite.org/lang_createindex.html#unique_indexes).
+    See [index] for how to use it
   ]##

--- a/tests/testAll.nim
+++ b/tests/testAll.nim
@@ -31,6 +31,7 @@ type
     title {.index.}: string
     tag {.index: "extra_idx".}: string
     info {.index: "extra_idx".}: string
+    extra {.uniqueIndex.}: string
 
 func `$`(d: Dog): string =
   if d != nil:
@@ -41,7 +42,7 @@ func `$`(d: Dog): string =
 func `==`(a, b: Dog): bool =
   a.name == b.name and a.owner == b.owner
 
-let db = newConn("tmp.db")
+let db = newConn(":memory:")
 
 test "Table creation":
   db.create(Person, Dog, Something, Model)
@@ -206,9 +207,12 @@ suite "Index":
     fmt"USING INDEX {index}" in plan
 
   test "Index is used for single column":
-    check "SELECT * FROM Model WHERE title = 'test'".usesIndex("Model_title")
+    check "SELECT * FROM Model WHERE title = 'test'".usesIndex("Model_index_title")
 
   test "Index is used for multi column":
-    check "SELECT * FROM Model WHERE tag = 'a' AND info = 'b'".usesIndex("Model_extra_idx")
+    check "SELECT * FROM Model WHERE tag = 'a' AND info = 'b'".usesIndex("Model_index_extra_idx")
+
+  test "Unique index can be used":
+    check "SELECT * FROM Model WHERE extra = 'foo'".usesIndex("Model_index_unique_extra")
 
 close db


### PR DESCRIPTION
Closes #15 

Adds support for creating normal indexes and unique indexes.

```nim
type
  Modal = object
    foo {.index.}: string # Creates an index that is only used by foo
    # An index can be used by multiple columns by giving it a name
    something {.index: "shared".}: string
    bar {.index: "shared".}: string
    # Unique indexes operate the same way
    yup {.uniqueIndex.}: 
    more {.uniqueIndex: "unique".}
```

Also adds the `explain` proc which I used for writing the tests, this just returns the query plan that SQLite will use