### PR TITLE
Implement faster insertion

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,37 +12,36 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        nim: ['2.0.0', 'stable', 'devel']
+        nim: ["2.2.0", "stable", "devel"]
 
     name: Nim ${{ matrix.nim }}
     steps:
+      - name: Setup Nim Enviroment
+        uses: actions/checkout@v6
 
-    - name: Setup Nim Enviroment
-      uses: actions/checkout@v6
+      - uses: iffy/install-nim@v5
+        with:
+          version: ${{ matrix.nim }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - uses: iffy/install-nim@v5
-      with:
-        version: ${{ matrix.nim }}
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Cache choosenim
+        id: cache-choosenim
+        uses: actions/cache@v5
+        with:
+          path: ~/.nimble
+          key: nimble-${{ hashFiles('*.nimble') }}
 
-    - name: Cache choosenim
-      id: cache-choosenim
-      uses: actions/cache@v5
-      with:
-        path: ~/.nimble
-        key: nimble-${{ hashFiles('*.nimble') }}
+      - if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
+        name: Install nim dependencies
+        continue-on-error: true
+        run: nimble update && nimble install
 
-    - if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
-      name: Install nim dependencies
-      continue-on-error: true
-      run: nimble update && nimble install
+      - name: Run Tests
+        run: nimble test
 
-    - name: Run Tests
-      run: nimble test
-
-    - name: Test doc examples
-      run: nimble doc --warningAsError:BrokenLink:on --project src/ponairi.nim
+      - name: Test doc examples
+        run: nimble doc --warningAsError:BrokenLink:on --project src/ponairi.nim
 
   deploy:
     name: Documentation
@@ -65,7 +64,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "Build documentation"
-        uses: ire4ever1190/nim-docs-action@v1
+        uses: ire4ever1190/nim-docs-action@v2
         with:
           main-file: "src/ponairi.nim"
           deploy: "pages"

--- a/ponairi.nimble
+++ b/ponairi.nimble
@@ -10,4 +10,4 @@ srcDir        = "src"
 # Dependencies
 
 requires "nim >= 1.6.0"
-requires "lowdb >= 0.1.1"
+requires "lowdb#devel"

--- a/ponairi.nimble
+++ b/ponairi.nimble
@@ -9,5 +9,5 @@ srcDir        = "src"
 
 # Dependencies
 
-requires "nim >= 2.0.0"
+requires "nim >= 2.2.0"
 requires "https://github.com/ire4ever1190/lowdb#fix/conditional-dependency"

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 Simple ORM to handle basic CRUD tasks. Future plans are to expand the query generation to make needing to write SQL less common
 
-[Docs here](https://ire4ever1190.github.io/ponairi/ponairi.html)
+[Docs here](https://ire4ever1190.github.io/ponairi/stable/ponairi.html)
 
 ### Create
 
@@ -88,4 +88,3 @@ assert db.exists(tableOrder)
 db.delete(tableOrder)
 assert not db.exists(tableOrder)
 ```
-

--- a/src/ponairi.nim
+++ b/src/ponairi.nim
@@ -7,7 +7,8 @@ import std/[
   times,
   tables
 ]
-import pkg/lowdb/sqlite
+import pkg/lowdb/sqlite {.all.}
+import pkg/lowdb/wrappers/sqlite3
 
 import ponairi/[
   pragmas,
@@ -382,19 +383,16 @@ template countFields(x: typedesc, checker: untyped = true): int {.dirty.} =
         result += 1
   doCounting()
 
-template makeParams[T](item: T, checker: untyped = true): untyped {.dirty.} =
+template makeParams[T](item: T, checker: untyped = true): seq[DbValue] {.dirty.} =
   ## Converts an object into an array of `DBValue`. A checker can be passed
   ## to ignore certain fields.
   bind countFields
   bind fieldPairs
   const numFields = countFields(T, checker)
-  var
-    res: array[numFields, DbValue]
-    i = 0
+  var res = newSeqOfCap[DbValue](numFields)
   for name, field in fieldPairs(item):
     when checker:
-      res[i] = dbValue(field)
-      i += 1
+      res &= dbValue(field)
   res
 
 proc insert*[T: SomeTable](db; item: T) =

--- a/tests/testAll.nim
+++ b/tests/testAll.nim
@@ -4,7 +4,7 @@ import std/[
   strformat,
   strutils
 ]
-import ponairi {.all.}
+import ponairi
 
 type
   Status = enum


### PR DESCRIPTION
Implements faster insertion of items by reusing the prepared statement instead of recreating it for each item. From benchmarks it looks to be roughly 4x faster. I'm also using arrays instead seqs for storing `DbValue` which gives a minor performance boost in the benchmark (6ms -> 5ms)

Benchmark code
```nim
import benchy
import src/ponairi {.all.}
import strformat
import std/random

type
  Person = object
    name: string
    age: int
    alive: bool

  Item = object
    id {.primary.}: int
    name: string
    something: int

# I am uncreative with names
const names = ["Jake", "James", "John", "Jack"]

proc oldInsert*[T: SomeTable](db: DbConn, items: openArray[T]) =
  ## Inserts the list of items into the database.
  ## This gets ran in a transaction so if an error happens then none
  ## of the items are saved to the database
  db.transaction:
    for item in items:
      db.insert item

proc oldUpsert[T: SomeTable](db: DbConn, items: openArray[T], exclude: static[openArray[string]] = []) =
  db.transaction:
    for item in items:
      db.upsertImpl(item, exclude)

proc main() =
  var
    people: seq[Person]
    items: seq[Item]
  for i in 0..<10000:
    people &= Person(name: sample(names), age: rand(1..100), alive: rand(bool))
    items &= Item(id: i, name: sample(names), something: rand(1..1000))

  let db = newConn(":memory:")

  template recreate() =
    db.drop(Person)
    db.create(Person)
  recreate()

  timeIt "Old insertion":
    db.oldInsert(people)

  recreate()

  timeIt "New insertion":
    db.insert(people)

  recreate()
  db.create(Item)
  db.insert(items)

  timeIt "Old upsert":
    db.oldUpsert(items)

  timeIt "New upsert":
    db.upsert(items)


  close db
main()
```

`nim r -d:release bench.nim`
```
   min time    avg time  std dv   runs name
  22.913 ms   24.901 ms  ±1.870   x200 Old insertion
   4.646 ms    5.367 ms  ±0.724   x914 New insertion
  42.152 ms   45.104 ms  ±2.409   x111 Old upsert
   5.740 ms    5.843 ms  ±0.110   x849 New upsert
```

Todo

- [x]  Implement for normal inserting
- [x] Implement for upsert