### PR TITLE
Don't use `func` for `Option[T]` conversion

### DIFF
--- a/src/ponairi.nim
+++ b/src/ponairi.nim
@@ -483,7 +483,7 @@ func dbValue*(e: enum): DbValue =
 func to*(src: DbValue, dest: var string) {.inline.} = dest = src.s
 func to*[T: SomeOrdinal](src: DbValue, dest: var T) {.inline.} = dest = T(src.i)
 func to*[T: SomeFloat](src: DbValue, dest: var T) {.inline.} = dest = T(src.f)
-func to*[T](src: DbValue, dest: var Option[T]) =
+proc to*[T](src: DbValue, dest: var Option[T]) =
   if src.kind != dvkNull:
     when T is SomeTable:
       var val = T()

--- a/tests/testAll.nim
+++ b/tests/testAll.nim
@@ -2,7 +2,8 @@ import std/[
   unittest,
   options,
   strformat,
-  strutils
+  strutils,
+  times
 ]
 import ponairi {.all.}
 
@@ -21,6 +22,7 @@ type
   Dog* = ref object
     name {.primary.}: string
     owner* {.references(Person.name), cascade.}: string
+    other: Option[DateTime]
 
   Something* = object
     name*, age*: string


### PR DESCRIPTION
This is to support things like Option[DateTime] which do have side effects